### PR TITLE
리뷰 요청 인박스 null 센티널 제거

### DIFF
--- a/src/main/java/com/slack/bot/application/interaction/box/InteractionImmediateProcessor.java
+++ b/src/main/java/com/slack/bot/application/interaction/box/InteractionImmediateProcessor.java
@@ -43,12 +43,9 @@ public class InteractionImmediateProcessor {
             return;
         }
 
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                runAsync(taskName, runnable);
-            }
-        });
+        TransactionSynchronizationManager.registerSynchronization(
+                new AfterCommitSynchronization(taskName, runnable)
+        );
     }
 
     private boolean isTransactionActive() {
@@ -72,6 +69,22 @@ public class InteractionImmediateProcessor {
             runnable.run();
         } catch (Exception e) {
             log.error("{}에 실패했습니다. 스케줄러 복구에 위임합니다.", taskName, e);
+        }
+    }
+
+    private final class AfterCommitSynchronization implements TransactionSynchronization {
+
+        private final String taskName;
+        private final Runnable runnable;
+
+        private AfterCommitSynchronization(String taskName, Runnable runnable) {
+            this.taskName = taskName;
+            this.runnable = runnable;
+        }
+
+        @Override
+        public void afterCommit() {
+            runAsync(taskName, runnable);
         }
     }
 }

--- a/src/main/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessor.java
+++ b/src/main/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessor.java
@@ -38,7 +38,7 @@ public class ReviewRequestInboxEntryProcessor {
             Instant claimedProcessingStartedAt
     ) {
         if (!hasProcessingLease(inbox, claimedProcessingStartedAt)) {
-            logLeaseLost(inbox.getId(), claimedProcessingStartedAt, inbox.getProcessingStartedAt());
+            logLeaseLost(inbox.getId(), claimedProcessingStartedAt, actualProcessingStartedAt(inbox));
             return;
         }
 
@@ -68,7 +68,15 @@ public class ReviewRequestInboxEntryProcessor {
             ReviewRequestInbox inbox,
             Instant claimedProcessingStartedAt
     ) {
-        return claimedProcessingStartedAt.equals(inbox.getProcessingStartedAt());
+        return inbox.hasClaimedProcessingLease(claimedProcessingStartedAt);
+    }
+
+    private Instant actualProcessingStartedAt(ReviewRequestInbox inbox) {
+        if (!inbox.hasClaimedProcessingLease()) {
+            return null;
+        }
+
+        return inbox.currentProcessingLeaseStartedAt();
     }
 
     private void logLeaseLost(

--- a/src/main/java/com/slack/bot/application/review/box/in/ReviewRequestInboxTransactionalProcessor.java
+++ b/src/main/java/com/slack/bot/application/review/box/in/ReviewRequestInboxTransactionalProcessor.java
@@ -9,8 +9,8 @@ import com.slack.bot.application.review.box.in.exception.ReviewRequestInboxProce
 import com.slack.bot.application.review.dto.ReviewNotificationPayload;
 import com.slack.bot.global.config.properties.InteractionRetryProperties;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
-import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxHistory;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
+import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxHistory;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
 import com.slack.bot.infrastructure.review.box.in.repository.ReviewRequestInboxRepository;
 import java.time.Clock;

--- a/src/main/java/com/slack/bot/infrastructure/interaction/box/persistence/in/SlackInteractionInboxRepositoryAdapter.java
+++ b/src/main/java/com/slack/bot/infrastructure/interaction/box/persistence/in/SlackInteractionInboxRepositoryAdapter.java
@@ -356,7 +356,9 @@ public class SlackInteractionInboxRepositoryAdapter implements SlackInteractionI
     @Override
     @Transactional
     public SlackInteractionInbox save(SlackInteractionInbox inbox) {
-        SlackInteractionInboxJpaEntity entity = findInboxEntity(inbox.getId()).orElseGet(SlackInteractionInboxJpaEntity::new);
+        SlackInteractionInboxJpaEntity entity = findInboxEntity(inbox.getId()).orElseGet(
+                () -> new SlackInteractionInboxJpaEntity()
+        );
         entity.apply(inbox);
         return repository.save(entity).toDomain();
     }

--- a/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInbox.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInbox.java
@@ -1,46 +1,25 @@
 package com.slack.bot.infrastructure.review.box.in;
 
-import com.slack.bot.domain.common.BaseTimeEntity;
 import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
 import java.time.Instant;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
-@Table(name = "review_request_inbox")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReviewRequestInbox extends BaseTimeEntity {
+public class ReviewRequestInbox {
 
-    private String idempotencyKey;
+    private final Long id;
+    private final String idempotencyKey;
+    private final String apiKey;
+    private final Long githubPullRequestId;
+    private final String requestJson;
+    private final Instant availableAt;
 
-    private String apiKey;
-
-    private Long githubPullRequestId;
-
-    private String requestJson;
-
-    private Instant availableAt;
-
-    @Enumerated(EnumType.STRING)
     private ReviewRequestInboxStatus status;
-
     private int processingAttempt;
-
     private Instant processingStartedAt;
-
     private Instant processedAt;
-
     private Instant failedAt;
-
     private String failureReason;
-
-    @Enumerated(EnumType.STRING)
     private ReviewRequestInboxFailureType failureType;
 
     public static ReviewRequestInbox pending(
@@ -57,13 +36,171 @@ public class ReviewRequestInbox extends BaseTimeEntity {
         validateAvailableAt(availableAt);
 
         return new ReviewRequestInbox(
+                null,
                 idempotencyKey,
                 apiKey,
                 githubPullRequestId,
                 requestJson,
                 availableAt,
                 ReviewRequestInboxStatus.PENDING,
-                0
+                0,
+                FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT,
+                FailureSnapshotDefaults.NO_PROCESSED_AT,
+                FailureSnapshotDefaults.NO_FAILURE_AT,
+                FailureSnapshotDefaults.NO_FAILURE_REASON,
+                ReviewRequestInboxFailureType.NONE
+        );
+    }
+
+    public static ReviewRequestInbox rehydrate(
+            Long id,
+            String idempotencyKey,
+            String apiKey,
+            Long githubPullRequestId,
+            String requestJson,
+            Instant availableAt,
+            ReviewRequestInboxStatus status,
+            int processingAttempt,
+            Instant processingStartedAt,
+            Instant processedAt,
+            Instant failedAt,
+            String failureReason,
+            ReviewRequestInboxFailureType failureType
+    ) {
+        validateIdempotencyKey(idempotencyKey);
+        validateApiKey(apiKey);
+        validateGithubPullRequestId(githubPullRequestId);
+        validateRequestJson(requestJson);
+        validateAvailableAt(availableAt);
+        validateStatus(status);
+        validateProcessingAttempt(processingAttempt);
+        validateProcessingStartedAt(processingStartedAt);
+        validateProcessedAt(processedAt);
+        validateFailedAt(failedAt);
+        validateFailureReasonSnapshot(failureReason);
+        validateFailureTypeSnapshot(failureType);
+
+        return new ReviewRequestInbox(
+                id,
+                idempotencyKey,
+                apiKey,
+                githubPullRequestId,
+                requestJson,
+                availableAt,
+                status,
+                processingAttempt,
+                processingStartedAt,
+                processedAt,
+                failedAt,
+                failureReason,
+                failureType
+        );
+    }
+
+    private ReviewRequestInbox(
+            Long id,
+            String idempotencyKey,
+            String apiKey,
+            Long githubPullRequestId,
+            String requestJson,
+            Instant availableAt,
+            ReviewRequestInboxStatus status,
+            int processingAttempt,
+            Instant processingStartedAt,
+            Instant processedAt,
+            Instant failedAt,
+            String failureReason,
+            ReviewRequestInboxFailureType failureType
+    ) {
+        this.id = id;
+        this.idempotencyKey = idempotencyKey;
+        this.apiKey = apiKey;
+        this.githubPullRequestId = githubPullRequestId;
+        this.requestJson = requestJson;
+        this.availableAt = availableAt;
+        this.status = status;
+        this.processingAttempt = processingAttempt;
+        this.processingStartedAt = processingStartedAt;
+        this.processedAt = processedAt;
+        this.failedAt = failedAt;
+        this.failureReason = failureReason;
+        this.failureType = failureType;
+    }
+
+    public ReviewRequestInboxHistory markProcessed(Instant processedAt) {
+        validatePresentProcessedAt(processedAt);
+        validateTransition(ReviewRequestInboxStatus.PROCESSING, "PROCESSED");
+
+        this.status = ReviewRequestInboxStatus.PROCESSED;
+        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
+        this.processedAt = processedAt;
+        this.failedAt = FailureSnapshotDefaults.NO_FAILURE_AT;
+        this.failureReason = FailureSnapshotDefaults.NO_FAILURE_REASON;
+        this.failureType = ReviewRequestInboxFailureType.NONE;
+
+        return ReviewRequestInboxHistory.completed(
+                getId(),
+                this.processingAttempt,
+                ReviewRequestInboxStatus.PROCESSED,
+                processedAt,
+                FailureSnapshotDefaults.NO_FAILURE_REASON,
+                ReviewRequestInboxFailureType.NONE
+        );
+    }
+
+    public void renewProcessingLease(Instant processingStartedAt) {
+        validatePresentProcessingStartedAt(processingStartedAt);
+        validateTransition(ReviewRequestInboxStatus.PROCESSING, "PROCESSING");
+
+        this.processingStartedAt = processingStartedAt;
+    }
+
+    public ReviewRequestInboxHistory markRetryPending(Instant failedAt, String failureReason) {
+        validatePresentFailedAt(failedAt);
+        validatePresentFailureReason(failureReason);
+        validateTransition(ReviewRequestInboxStatus.PROCESSING, "RETRY_PENDING");
+
+        this.status = ReviewRequestInboxStatus.RETRY_PENDING;
+        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
+        this.processedAt = FailureSnapshotDefaults.NO_PROCESSED_AT;
+        this.failedAt = failedAt;
+        this.failureReason = failureReason;
+        this.failureType = ReviewRequestInboxFailureType.NONE;
+
+        return ReviewRequestInboxHistory.completed(
+                getId(),
+                this.processingAttempt,
+                ReviewRequestInboxStatus.RETRY_PENDING,
+                failedAt,
+                failureReason,
+                ReviewRequestInboxFailureType.NONE
+        );
+    }
+
+    public ReviewRequestInboxHistory markFailed(
+            Instant failedAt,
+            String failureReason,
+            ReviewRequestInboxFailureType failureType
+    ) {
+        validatePresentFailedAt(failedAt);
+        validatePresentFailureReason(failureReason);
+        validatePresentFailureType(failureType);
+        validateTransition(ReviewRequestInboxStatus.PROCESSING, "FAILED");
+
+        this.status = ReviewRequestInboxStatus.FAILED;
+        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
+        this.processedAt = FailureSnapshotDefaults.NO_PROCESSED_AT;
+        this.failedAt = failedAt;
+        this.failureReason = failureReason;
+        this.failureType = failureType;
+
+        return ReviewRequestInboxHistory.completed(
+                getId(),
+                this.processingAttempt,
+                ReviewRequestInboxStatus.FAILED,
+                failedAt,
+                failureReason,
+                failureType
         );
     }
 
@@ -97,131 +234,73 @@ public class ReviewRequestInbox extends BaseTimeEntity {
         }
     }
 
-    private ReviewRequestInbox(
-            String idempotencyKey,
-            String apiKey,
-            Long githubPullRequestId,
-            String requestJson,
-            Instant availableAt,
-            ReviewRequestInboxStatus status,
-            int processingAttempt
-    ) {
-        this.idempotencyKey = idempotencyKey;
-        this.apiKey = apiKey;
-        this.githubPullRequestId = githubPullRequestId;
-        this.requestJson = requestJson;
-        this.availableAt = availableAt;
-        this.status = status;
-        this.processingAttempt = processingAttempt;
-        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
-        this.processedAt = FailureSnapshotDefaults.NO_PROCESSED_AT;
-        this.failedAt = FailureSnapshotDefaults.NO_FAILURE_AT;
-        this.failureReason = FailureSnapshotDefaults.NO_FAILURE_REASON;
-        this.failureType = ReviewRequestInboxFailureType.NONE;
-    }
-
-    public ReviewRequestInboxHistory markProcessed(Instant processedAt) {
-        validateProcessedAt(processedAt);
-        validateTransition(ReviewRequestInboxStatus.PROCESSING, "PROCESSED");
-
-        this.status = ReviewRequestInboxStatus.PROCESSED;
-        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
-        this.processedAt = processedAt;
-        this.failedAt = FailureSnapshotDefaults.NO_FAILURE_AT;
-        this.failureReason = FailureSnapshotDefaults.NO_FAILURE_REASON;
-        this.failureType = ReviewRequestInboxFailureType.NONE;
-
-        return ReviewRequestInboxHistory.completed(
-                getId(),
-                this.processingAttempt,
-                ReviewRequestInboxStatus.PROCESSED,
-                processedAt,
-                FailureSnapshotDefaults.NO_FAILURE_REASON,
-                ReviewRequestInboxFailureType.NONE
-        );
-    }
-
-    public void renewProcessingLease(Instant processingStartedAt) {
-        validateProcessingStartedAt(processingStartedAt);
-        validateTransition(ReviewRequestInboxStatus.PROCESSING, "PROCESSING");
-
-        this.processingStartedAt = processingStartedAt;
-    }
-
-    public ReviewRequestInboxHistory markRetryPending(Instant failedAt, String failureReason) {
-        validateFailedAt(failedAt);
-        validateFailureReason(failureReason);
-        validateTransition(ReviewRequestInboxStatus.PROCESSING, "RETRY_PENDING");
-
-        this.status = ReviewRequestInboxStatus.RETRY_PENDING;
-        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
-        this.processedAt = FailureSnapshotDefaults.NO_PROCESSED_AT;
-        this.failedAt = failedAt;
-        this.failureReason = failureReason;
-        this.failureType = ReviewRequestInboxFailureType.NONE;
-
-        return ReviewRequestInboxHistory.completed(
-                getId(),
-                this.processingAttempt,
-                ReviewRequestInboxStatus.RETRY_PENDING,
-                failedAt,
-                failureReason,
-                ReviewRequestInboxFailureType.NONE
-        );
-    }
-
-    public ReviewRequestInboxHistory markFailed(
-            Instant failedAt,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
-    ) {
-        validateFailedAt(failedAt);
-        validateFailureReason(failureReason);
-        validateFailureType(failureType);
-        validateTransition(ReviewRequestInboxStatus.PROCESSING, "FAILED");
-
-        this.status = ReviewRequestInboxStatus.FAILED;
-        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
-        this.processedAt = FailureSnapshotDefaults.NO_PROCESSED_AT;
-        this.failedAt = failedAt;
-        this.failureReason = failureReason;
-        this.failureType = failureType;
-
-        return ReviewRequestInboxHistory.completed(
-                getId(),
-                this.processingAttempt,
-                ReviewRequestInboxStatus.FAILED,
-                failedAt,
-                failureReason,
-                failureType
-        );
-    }
-
-    private void validateProcessedAt(Instant processedAt) {
-        if (processedAt == null) {
-            throw new IllegalArgumentException("processedAt은 비어 있을 수 없습니다.");
+    private static void validateStatus(ReviewRequestInboxStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("status는 비어 있을 수 없습니다.");
         }
     }
 
-    private void validateProcessingStartedAt(Instant processingStartedAt) {
+    private static void validateProcessingAttempt(int processingAttempt) {
+        if (processingAttempt < 0) {
+            throw new IllegalArgumentException("processingAttempt는 0 이상이어야 합니다.");
+        }
+    }
+
+    private static void validateProcessingStartedAt(Instant processingStartedAt) {
         if (processingStartedAt == null) {
             throw new IllegalArgumentException("processingStartedAt은 비어 있을 수 없습니다.");
         }
     }
 
-    private void validateFailedAt(Instant failedAt) {
+    private static void validateProcessedAt(Instant processedAt) {
+        if (processedAt == null) {
+            throw new IllegalArgumentException("processedAt은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateFailedAt(Instant failedAt) {
         if (failedAt == null) {
             throw new IllegalArgumentException("failedAt은 비어 있을 수 없습니다.");
         }
     }
 
-    private void validateFailureReason(String failureReason) {
+    private static void validateFailureReasonSnapshot(String failureReason) {
+        if (failureReason == null) {
+            throw new IllegalArgumentException("failureReason은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateFailureTypeSnapshot(ReviewRequestInboxFailureType failureType) {
+        if (failureType == null) {
+            throw new IllegalArgumentException("failureType은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private void validatePresentProcessedAt(Instant processedAt) {
+        if (processedAt == null) {
+            throw new IllegalArgumentException("processedAt은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private void validatePresentProcessingStartedAt(Instant processingStartedAt) {
+        if (processingStartedAt == null) {
+            throw new IllegalArgumentException("processingStartedAt은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private void validatePresentFailedAt(Instant failedAt) {
+        if (failedAt == null) {
+            throw new IllegalArgumentException("failedAt은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private void validatePresentFailureReason(String failureReason) {
         if (failureReason == null || failureReason.isBlank()) {
             throw new IllegalArgumentException("failureReason은 비어 있을 수 없습니다.");
         }
     }
 
-    private void validateFailureType(ReviewRequestInboxFailureType failureType) {
+    private void validatePresentFailureType(ReviewRequestInboxFailureType failureType) {
         if (failureType == null || failureType == ReviewRequestInboxFailureType.NONE) {
             throw new IllegalArgumentException("failureType은 NONE일 수 없습니다.");
         }

--- a/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInbox.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInbox.java
@@ -1,6 +1,8 @@
 package com.slack.bot.infrastructure.review.box.in;
 
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import java.time.Instant;
 import lombok.Getter;
 
@@ -16,11 +18,10 @@ public class ReviewRequestInbox {
 
     private ReviewRequestInboxStatus status;
     private int processingAttempt;
-    private Instant processingStartedAt;
-    private Instant processedAt;
-    private Instant failedAt;
-    private String failureReason;
-    private ReviewRequestInboxFailureType failureType;
+    private BoxProcessingLease processingLease;
+    private BoxEventTime processedTime;
+    private BoxEventTime failedTime;
+    private BoxFailureSnapshot<ReviewRequestInboxFailureType> failure;
 
     public static ReviewRequestInbox pending(
             String idempotencyKey,
@@ -44,11 +45,10 @@ public class ReviewRequestInbox {
                 availableAt,
                 ReviewRequestInboxStatus.PENDING,
                 0,
-                FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT,
-                FailureSnapshotDefaults.NO_PROCESSED_AT,
-                FailureSnapshotDefaults.NO_FAILURE_AT,
-                FailureSnapshotDefaults.NO_FAILURE_REASON,
-                ReviewRequestInboxFailureType.NONE
+                BoxProcessingLease.idle(),
+                BoxEventTime.absent(),
+                BoxEventTime.absent(),
+                BoxFailureSnapshot.absent()
         );
     }
 
@@ -61,11 +61,10 @@ public class ReviewRequestInbox {
             Instant availableAt,
             ReviewRequestInboxStatus status,
             int processingAttempt,
-            Instant processingStartedAt,
-            Instant processedAt,
-            Instant failedAt,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
     ) {
         validateIdempotencyKey(idempotencyKey);
         validateApiKey(apiKey);
@@ -74,11 +73,11 @@ public class ReviewRequestInbox {
         validateAvailableAt(availableAt);
         validateStatus(status);
         validateProcessingAttempt(processingAttempt);
-        validateProcessingStartedAt(processingStartedAt);
-        validateProcessedAt(processedAt);
-        validateFailedAt(failedAt);
-        validateFailureReasonSnapshot(failureReason);
-        validateFailureTypeSnapshot(failureType);
+        validateProcessingLease(processingLease);
+        validateProcessedTime(processedTime);
+        validateFailedTime(failedTime);
+        validateFailure(failure);
+        validateState(status, processingAttempt, processingLease, processedTime, failedTime, failure);
 
         return new ReviewRequestInbox(
                 id,
@@ -89,11 +88,10 @@ public class ReviewRequestInbox {
                 availableAt,
                 status,
                 processingAttempt,
-                processingStartedAt,
-                processedAt,
-                failedAt,
-                failureReason,
-                failureType
+                processingLease,
+                processedTime,
+                failedTime,
+                failure
         );
     }
 
@@ -106,11 +104,10 @@ public class ReviewRequestInbox {
             Instant availableAt,
             ReviewRequestInboxStatus status,
             int processingAttempt,
-            Instant processingStartedAt,
-            Instant processedAt,
-            Instant failedAt,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
     ) {
         this.id = id;
         this.idempotencyKey = idempotencyKey;
@@ -120,60 +117,84 @@ public class ReviewRequestInbox {
         this.availableAt = availableAt;
         this.status = status;
         this.processingAttempt = processingAttempt;
-        this.processingStartedAt = processingStartedAt;
-        this.processedAt = processedAt;
-        this.failedAt = failedAt;
-        this.failureReason = failureReason;
-        this.failureType = failureType;
+        this.processingLease = processingLease;
+        this.processedTime = processedTime;
+        this.failedTime = failedTime;
+        this.failure = failure;
     }
 
     public ReviewRequestInboxHistory markProcessed(Instant processedAt) {
-        validatePresentProcessedAt(processedAt);
+        validateProcessedAt(processedAt);
         validateTransition(ReviewRequestInboxStatus.PROCESSING, "PROCESSED");
 
         this.status = ReviewRequestInboxStatus.PROCESSED;
-        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
-        this.processedAt = processedAt;
-        this.failedAt = FailureSnapshotDefaults.NO_FAILURE_AT;
-        this.failureReason = FailureSnapshotDefaults.NO_FAILURE_REASON;
-        this.failureType = ReviewRequestInboxFailureType.NONE;
+        this.processingLease = BoxProcessingLease.idle();
+        this.processedTime = BoxEventTime.present(processedAt);
+        this.failedTime = BoxEventTime.absent();
+        this.failure = BoxFailureSnapshot.absent();
 
         return ReviewRequestInboxHistory.completed(
                 getId(),
                 this.processingAttempt,
                 ReviewRequestInboxStatus.PROCESSED,
                 processedAt,
-                FailureSnapshotDefaults.NO_FAILURE_REASON,
-                ReviewRequestInboxFailureType.NONE
+                BoxFailureSnapshot.absent()
         );
     }
 
     public void renewProcessingLease(Instant processingStartedAt) {
-        validatePresentProcessingStartedAt(processingStartedAt);
+        validateProcessingStartedAt(processingStartedAt);
         validateTransition(ReviewRequestInboxStatus.PROCESSING, "PROCESSING");
 
-        this.processingStartedAt = processingStartedAt;
+        this.processingLease = BoxProcessingLease.claimed(processingStartedAt);
+    }
+
+    public boolean hasClaimedProcessingLease() {
+        return processingLease.isClaimed();
+    }
+
+    public boolean hasClaimedProcessingLease(Instant processingStartedAt) {
+        if (!hasClaimedProcessingLease()) {
+            return false;
+        }
+
+        return processingLease.startedAt().equals(processingStartedAt);
+    }
+
+    public Instant currentProcessingLeaseStartedAt() {
+        if (!hasClaimedProcessingLease()) {
+            throw new IllegalStateException("processingLease를 보유하고 있지 않습니다.");
+        }
+
+        return processingLease.startedAt();
     }
 
     public ReviewRequestInboxHistory markRetryPending(Instant failedAt, String failureReason) {
-        validatePresentFailedAt(failedAt);
-        validatePresentFailureReason(failureReason);
+        return markRetryPending(failedAt, failureReason, ReviewRequestInboxFailureType.RETRYABLE);
+    }
+
+    public ReviewRequestInboxHistory markRetryPending(
+            Instant failedAt,
+            String failureReason,
+            ReviewRequestInboxFailureType failureType
+    ) {
+        validateFailedAt(failedAt);
+        validateFailureReason(failureReason);
+        validateRetryPendingFailureType(failureType);
         validateTransition(ReviewRequestInboxStatus.PROCESSING, "RETRY_PENDING");
 
         this.status = ReviewRequestInboxStatus.RETRY_PENDING;
-        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
-        this.processedAt = FailureSnapshotDefaults.NO_PROCESSED_AT;
-        this.failedAt = failedAt;
-        this.failureReason = failureReason;
-        this.failureType = ReviewRequestInboxFailureType.NONE;
+        this.processingLease = BoxProcessingLease.idle();
+        this.processedTime = BoxEventTime.absent();
+        this.failedTime = BoxEventTime.present(failedAt);
+        this.failure = BoxFailureSnapshot.present(failureReason, failureType);
 
         return ReviewRequestInboxHistory.completed(
                 getId(),
                 this.processingAttempt,
                 ReviewRequestInboxStatus.RETRY_PENDING,
                 failedAt,
-                failureReason,
-                ReviewRequestInboxFailureType.NONE
+                BoxFailureSnapshot.present(failureReason, failureType)
         );
     }
 
@@ -182,25 +203,23 @@ public class ReviewRequestInbox {
             String failureReason,
             ReviewRequestInboxFailureType failureType
     ) {
-        validatePresentFailedAt(failedAt);
-        validatePresentFailureReason(failureReason);
-        validatePresentFailureType(failureType);
+        validateFailedAt(failedAt);
+        validateFailureReason(failureReason);
+        validateFailedFailureType(failureType);
         validateTransition(ReviewRequestInboxStatus.PROCESSING, "FAILED");
 
         this.status = ReviewRequestInboxStatus.FAILED;
-        this.processingStartedAt = FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT;
-        this.processedAt = FailureSnapshotDefaults.NO_PROCESSED_AT;
-        this.failedAt = failedAt;
-        this.failureReason = failureReason;
-        this.failureType = failureType;
+        this.processingLease = BoxProcessingLease.idle();
+        this.processedTime = BoxEventTime.absent();
+        this.failedTime = BoxEventTime.present(failedAt);
+        this.failure = BoxFailureSnapshot.present(failureReason, failureType);
 
         return ReviewRequestInboxHistory.completed(
                 getId(),
                 this.processingAttempt,
                 ReviewRequestInboxStatus.FAILED,
                 failedAt,
-                failureReason,
-                failureType
+                BoxFailureSnapshot.present(failureReason, failureType)
         );
     }
 
@@ -246,64 +265,225 @@ public class ReviewRequestInbox {
         }
     }
 
-    private static void validateProcessingStartedAt(Instant processingStartedAt) {
-        if (processingStartedAt == null) {
-            throw new IllegalArgumentException("processingStartedAt은 비어 있을 수 없습니다.");
+    private static void validateProcessingLease(BoxProcessingLease processingLease) {
+        if (processingLease == null) {
+            throw new IllegalArgumentException("processingLease는 비어 있을 수 없습니다.");
         }
     }
 
-    private static void validateProcessedAt(Instant processedAt) {
+    private static void validateProcessedTime(BoxEventTime processedTime) {
+        if (processedTime == null) {
+            throw new IllegalArgumentException("processedTime은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateFailedTime(BoxEventTime failedTime) {
+        if (failedTime == null) {
+            throw new IllegalArgumentException("failedTime은 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateFailure(BoxFailureSnapshot<ReviewRequestInboxFailureType> failure) {
+        if (failure == null) {
+            throw new IllegalArgumentException("failure는 비어 있을 수 없습니다.");
+        }
+    }
+
+    private static void validateState(
+            ReviewRequestInboxStatus status,
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
+    ) {
+        if (status == ReviewRequestInboxStatus.PENDING) {
+            validatePendingState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+        if (status == ReviewRequestInboxStatus.PROCESSING) {
+            validateProcessingState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+        if (status == ReviewRequestInboxStatus.PROCESSED) {
+            validateProcessedState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+        if (status == ReviewRequestInboxStatus.RETRY_PENDING) {
+            validateRetryPendingState(processingAttempt, processingLease, processedTime, failedTime, failure);
+            return;
+        }
+
+        validateFailedState(processingAttempt, processingLease, processedTime, failedTime, failure);
+    }
+
+    private static void validatePendingState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
+    ) {
+        if (processingAttempt != 0) {
+            throw new IllegalArgumentException("PENDING 상태의 processingAttempt는 0이어야 합니다.");
+        }
+        validateIdleLease(processingLease, "PENDING");
+        validateProcessedTimeAbsent(processedTime, "PENDING");
+        validateFailedStateAbsent(failedTime, failure, "PENDING");
+    }
+
+    private static void validateProcessingState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "PROCESSING");
+        if (!processingLease.isClaimed()) {
+            throw new IllegalArgumentException("PROCESSING 상태는 processingLease를 보유해야 합니다.");
+        }
+        validateProcessedTimeAbsent(processedTime, "PROCESSING");
+        validateFailedStateAbsent(failedTime, failure, "PROCESSING");
+    }
+
+    private static void validateProcessedState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "PROCESSED");
+        validateIdleLease(processingLease, "PROCESSED");
+        if (!processedTime.isPresent()) {
+            throw new IllegalArgumentException("PROCESSED 상태는 processedTime이 있어야 합니다.");
+        }
+        validateFailedStateAbsent(failedTime, failure, "PROCESSED");
+    }
+
+    private static void validateRetryPendingState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "RETRY_PENDING");
+        validateIdleLease(processingLease, "RETRY_PENDING");
+        validateProcessedTimeAbsent(processedTime, "RETRY_PENDING");
+        validateFailedStatePresent(failedTime, failure, "RETRY_PENDING");
+
+        ReviewRequestInboxFailureType failureType = failure.type();
+        if (failureType != ReviewRequestInboxFailureType.RETRYABLE
+                && failureType != ReviewRequestInboxFailureType.PROCESSING_TIMEOUT) {
+            throw new IllegalArgumentException("RETRY_PENDING 상태의 failureType이 올바르지 않습니다.");
+        }
+    }
+
+    private static void validateFailedState(
+            int processingAttempt,
+            BoxProcessingLease processingLease,
+            BoxEventTime processedTime,
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
+    ) {
+        validateProcessedAttemptStarted(processingAttempt, "FAILED");
+        validateIdleLease(processingLease, "FAILED");
+        validateProcessedTimeAbsent(processedTime, "FAILED");
+        validateFailedStatePresent(failedTime, failure, "FAILED");
+
+        ReviewRequestInboxFailureType failureType = failure.type();
+        if (failureType != ReviewRequestInboxFailureType.NON_RETRYABLE
+                && failureType != ReviewRequestInboxFailureType.RETRY_EXHAUSTED) {
+            throw new IllegalArgumentException("FAILED 상태의 failureType이 올바르지 않습니다.");
+        }
+    }
+
+    private static void validateProcessedAttemptStarted(int processingAttempt, String statusName) {
+        if (processingAttempt <= 0) {
+            throw new IllegalArgumentException(statusName + " 상태의 processingAttempt는 1 이상이어야 합니다.");
+        }
+    }
+
+    private static void validateIdleLease(BoxProcessingLease processingLease, String statusName) {
+        if (processingLease.isClaimed()) {
+            throw new IllegalArgumentException(statusName + " 상태는 processingLease가 비어 있어야 합니다.");
+        }
+    }
+
+    private static void validateProcessedTimeAbsent(BoxEventTime processedTime, String statusName) {
+        if (processedTime.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 processedTime이 비어 있어야 합니다.");
+        }
+    }
+
+    private static void validateFailedStateAbsent(
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure,
+            String statusName
+    ) {
+        if (failedTime.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failedTime이 비어 있어야 합니다.");
+        }
+        if (failure.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failure가 비어 있어야 합니다.");
+        }
+    }
+
+    private static void validateFailedStatePresent(
+            BoxEventTime failedTime,
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure,
+            String statusName
+    ) {
+        if (!failedTime.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failedTime이 있어야 합니다.");
+        }
+        if (!failure.isPresent()) {
+            throw new IllegalArgumentException(statusName + " 상태는 failure가 있어야 합니다.");
+        }
+    }
+
+    private void validateProcessedAt(Instant processedAt) {
         if (processedAt == null) {
             throw new IllegalArgumentException("processedAt은 비어 있을 수 없습니다.");
         }
     }
 
-    private static void validateFailedAt(Instant failedAt) {
-        if (failedAt == null) {
-            throw new IllegalArgumentException("failedAt은 비어 있을 수 없습니다.");
-        }
-    }
-
-    private static void validateFailureReasonSnapshot(String failureReason) {
-        if (failureReason == null) {
-            throw new IllegalArgumentException("failureReason은 비어 있을 수 없습니다.");
-        }
-    }
-
-    private static void validateFailureTypeSnapshot(ReviewRequestInboxFailureType failureType) {
-        if (failureType == null) {
-            throw new IllegalArgumentException("failureType은 비어 있을 수 없습니다.");
-        }
-    }
-
-    private void validatePresentProcessedAt(Instant processedAt) {
-        if (processedAt == null) {
-            throw new IllegalArgumentException("processedAt은 비어 있을 수 없습니다.");
-        }
-    }
-
-    private void validatePresentProcessingStartedAt(Instant processingStartedAt) {
+    private void validateProcessingStartedAt(Instant processingStartedAt) {
         if (processingStartedAt == null) {
             throw new IllegalArgumentException("processingStartedAt은 비어 있을 수 없습니다.");
         }
     }
 
-    private void validatePresentFailedAt(Instant failedAt) {
+    private void validateFailedAt(Instant failedAt) {
         if (failedAt == null) {
             throw new IllegalArgumentException("failedAt은 비어 있을 수 없습니다.");
         }
     }
 
-    private void validatePresentFailureReason(String failureReason) {
+    private void validateFailureReason(String failureReason) {
         if (failureReason == null || failureReason.isBlank()) {
             throw new IllegalArgumentException("failureReason은 비어 있을 수 없습니다.");
         }
     }
 
-    private void validatePresentFailureType(ReviewRequestInboxFailureType failureType) {
-        if (failureType == null || failureType == ReviewRequestInboxFailureType.NONE) {
-            throw new IllegalArgumentException("failureType은 NONE일 수 없습니다.");
+    private void validateRetryPendingFailureType(ReviewRequestInboxFailureType failureType) {
+        if (failureType == ReviewRequestInboxFailureType.RETRYABLE
+                || failureType == ReviewRequestInboxFailureType.PROCESSING_TIMEOUT) {
+            return;
         }
+
+        throw new IllegalArgumentException("RETRY_PENDING failureType이 올바르지 않습니다.");
+    }
+
+    private void validateFailedFailureType(ReviewRequestInboxFailureType failureType) {
+        if (failureType == ReviewRequestInboxFailureType.NON_RETRYABLE
+                || failureType == ReviewRequestInboxFailureType.RETRY_EXHAUSTED) {
+            return;
+        }
+
+        throw new IllegalArgumentException("FAILED failureType이 올바르지 않습니다.");
     }
 
     private void validateTransition(ReviewRequestInboxStatus expectedStatus, String targetStatus) {

--- a/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxFailureType.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxFailureType.java
@@ -1,7 +1,7 @@
 package com.slack.bot.infrastructure.review.box.in;
 
 public enum ReviewRequestInboxFailureType {
-    NONE,
+    RETRYABLE,
     PROCESSING_TIMEOUT,
     NON_RETRYABLE,
     RETRY_EXHAUSTED

--- a/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxHistory.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxHistory.java
@@ -1,6 +1,6 @@
 package com.slack.bot.infrastructure.review.box.in;
 
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
 import java.time.Instant;
 import lombok.Getter;
 
@@ -12,22 +12,20 @@ public class ReviewRequestInboxHistory {
     private final int processingAttempt;
     private final ReviewRequestInboxStatus status;
     private final Instant completedAt;
-    private final String failureReason;
-    private final ReviewRequestInboxFailureType failureType;
+    private final BoxFailureSnapshot<ReviewRequestInboxFailureType> failure;
 
     public static ReviewRequestInboxHistory completed(
             Long inboxId,
             int processingAttempt,
             ReviewRequestInboxStatus status,
             Instant completedAt,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
     ) {
         validateInboxIdIfPresent(inboxId);
         validateProcessingAttempt(processingAttempt);
         validateStatus(status);
         validateCompletedAt(completedAt);
-        validateFailure(status, failureReason, failureType);
+        validateFailure(status, failure);
 
         return new ReviewRequestInboxHistory(
                 null,
@@ -35,8 +33,7 @@ public class ReviewRequestInboxHistory {
                 processingAttempt,
                 status,
                 completedAt,
-                failureReason,
-                failureType
+                failure
         );
     }
 
@@ -46,14 +43,13 @@ public class ReviewRequestInboxHistory {
             int processingAttempt,
             ReviewRequestInboxStatus status,
             Instant completedAt,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
     ) {
         validateInboxIdIfPresent(inboxId);
         validateProcessingAttempt(processingAttempt);
         validateStatus(status);
         validateCompletedAt(completedAt);
-        validateFailure(status, failureReason, failureType);
+        validateFailure(status, failure);
 
         return new ReviewRequestInboxHistory(
                 id,
@@ -61,8 +57,7 @@ public class ReviewRequestInboxHistory {
                 processingAttempt,
                 status,
                 completedAt,
-                failureReason,
-                failureType
+                failure
         );
     }
 
@@ -72,16 +67,14 @@ public class ReviewRequestInboxHistory {
             int processingAttempt,
             ReviewRequestInboxStatus status,
             Instant completedAt,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
     ) {
         this.id = id;
         this.inboxId = inboxId;
         this.processingAttempt = processingAttempt;
         this.status = status;
         this.completedAt = completedAt;
-        this.failureReason = failureReason;
-        this.failureType = failureType;
+        this.failure = failure;
     }
 
     public ReviewRequestInboxHistory bindInboxId(Long inboxId) {
@@ -99,8 +92,7 @@ public class ReviewRequestInboxHistory {
                 processingAttempt,
                 status,
                 completedAt,
-                failureReason,
-                failureType
+                failure
         );
     }
 
@@ -128,9 +120,7 @@ public class ReviewRequestInboxHistory {
         if (status == null) {
             throw new IllegalArgumentException("status는 비어 있을 수 없습니다.");
         }
-        if (status == ReviewRequestInboxStatus.PENDING || status == ReviewRequestInboxStatus.PROCESSING) {
-            throw new IllegalArgumentException("history status는 완료된 상태여야 합니다.");
-        }
+        status.validateHistoryStatus();
     }
 
     private static void validateCompletedAt(Instant completedAt) {
@@ -141,33 +131,8 @@ public class ReviewRequestInboxHistory {
 
     private static void validateFailure(
             ReviewRequestInboxStatus status,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
+            BoxFailureSnapshot<ReviewRequestInboxFailureType> failure
     ) {
-        if (status == ReviewRequestInboxStatus.PROCESSED) {
-            if (!FailureSnapshotDefaults.NO_FAILURE_REASON.equals(failureReason)
-                    || failureType != ReviewRequestInboxFailureType.NONE) {
-                throw new IllegalArgumentException("PROCESSED history에는 실패 정보가 없어야 합니다.");
-            }
-            return;
-        }
-
-        if (failureReason == null || failureReason.isBlank()) {
-            throw new IllegalArgumentException("failureReason은 비어 있을 수 없습니다.");
-        }
-        if (status == ReviewRequestInboxStatus.FAILED) {
-            if (failureType == null || failureType == ReviewRequestInboxFailureType.NONE) {
-                throw new IllegalArgumentException("FAILED history에는 failureType이 필요합니다.");
-            }
-        }
-        if (status == ReviewRequestInboxStatus.RETRY_PENDING) {
-            if (failureType == null) {
-                throw new IllegalArgumentException("RETRY_PENDING history에는 failureType이 필요합니다.");
-            }
-            if (failureType != ReviewRequestInboxFailureType.NONE
-                    && failureType != ReviewRequestInboxFailureType.PROCESSING_TIMEOUT) {
-                throw new IllegalArgumentException("RETRY_PENDING history의 failureType이 올바르지 않습니다.");
-            }
-        }
+        status.validateHistoryFailure(failure);
     }
 }

--- a/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxHistory.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxHistory.java
@@ -1,35 +1,19 @@
 package com.slack.bot.infrastructure.review.box.in;
 
-import com.slack.bot.domain.common.BaseTimeEntity;
 import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
 import java.time.Instant;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@Entity
-@Table(name = "review_request_inbox_history")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReviewRequestInboxHistory extends BaseTimeEntity {
+public class ReviewRequestInboxHistory {
 
-    private Long inboxId;
-
-    private int processingAttempt;
-
-    @Enumerated(EnumType.STRING)
-    private ReviewRequestInboxStatus status;
-
-    private Instant completedAt;
-
-    private String failureReason;
-
-    @Enumerated(EnumType.STRING)
-    private ReviewRequestInboxFailureType failureType;
+    private final Long id;
+    private final Long inboxId;
+    private final int processingAttempt;
+    private final ReviewRequestInboxStatus status;
+    private final Instant completedAt;
+    private final String failureReason;
+    private final ReviewRequestInboxFailureType failureType;
 
     public static ReviewRequestInboxHistory completed(
             Long inboxId,
@@ -46,6 +30,7 @@ public class ReviewRequestInboxHistory extends BaseTimeEntity {
         validateFailure(status, failureReason, failureType);
 
         return new ReviewRequestInboxHistory(
+                null,
                 inboxId,
                 processingAttempt,
                 status,
@@ -53,6 +38,50 @@ public class ReviewRequestInboxHistory extends BaseTimeEntity {
                 failureReason,
                 failureType
         );
+    }
+
+    public static ReviewRequestInboxHistory rehydrate(
+            Long id,
+            Long inboxId,
+            int processingAttempt,
+            ReviewRequestInboxStatus status,
+            Instant completedAt,
+            String failureReason,
+            ReviewRequestInboxFailureType failureType
+    ) {
+        validateInboxIdIfPresent(inboxId);
+        validateProcessingAttempt(processingAttempt);
+        validateStatus(status);
+        validateCompletedAt(completedAt);
+        validateFailure(status, failureReason, failureType);
+
+        return new ReviewRequestInboxHistory(
+                id,
+                inboxId,
+                processingAttempt,
+                status,
+                completedAt,
+                failureReason,
+                failureType
+        );
+    }
+
+    private ReviewRequestInboxHistory(
+            Long id,
+            Long inboxId,
+            int processingAttempt,
+            ReviewRequestInboxStatus status,
+            Instant completedAt,
+            String failureReason,
+            ReviewRequestInboxFailureType failureType
+    ) {
+        this.id = id;
+        this.inboxId = inboxId;
+        this.processingAttempt = processingAttempt;
+        this.status = status;
+        this.completedAt = completedAt;
+        this.failureReason = failureReason;
+        this.failureType = failureType;
     }
 
     public ReviewRequestInboxHistory bindInboxId(Long inboxId) {
@@ -65,6 +94,7 @@ public class ReviewRequestInboxHistory extends BaseTimeEntity {
         }
 
         return new ReviewRequestInboxHistory(
+                this.id,
                 inboxId,
                 processingAttempt,
                 status,
@@ -72,22 +102,6 @@ public class ReviewRequestInboxHistory extends BaseTimeEntity {
                 failureReason,
                 failureType
         );
-    }
-
-    private ReviewRequestInboxHistory(
-            Long inboxId,
-            int processingAttempt,
-            ReviewRequestInboxStatus status,
-            Instant completedAt,
-            String failureReason,
-            ReviewRequestInboxFailureType failureType
-    ) {
-        this.inboxId = inboxId;
-        this.processingAttempt = processingAttempt;
-        this.status = status;
-        this.completedAt = completedAt;
-        this.failureReason = failureReason;
-        this.failureType = failureType;
     }
 
     private static void validateInboxId(Long inboxId) {

--- a/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxStatus.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxStatus.java
@@ -1,9 +1,107 @@
 package com.slack.bot.infrastructure.review.box.in;
 
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import java.util.EnumSet;
+import java.util.Set;
+
 public enum ReviewRequestInboxStatus {
-    PENDING,
-    PROCESSING,
-    RETRY_PENDING,
-    PROCESSED,
-    FAILED
+    PENDING(notCompleted()),
+    RETRY_PENDING(requiresFailureType(
+            "RETRY_PENDING history의 failureType이 올바르지 않습니다.",
+            EnumSet.of(
+                    ReviewRequestInboxFailureType.RETRYABLE,
+                    ReviewRequestInboxFailureType.PROCESSING_TIMEOUT
+            )
+    )),
+    PROCESSING(notCompleted()),
+    PROCESSED(requiresNoFailure("PROCESSED history에는 실패 정보가 없어야 합니다.")),
+    FAILED(requiresFailureType(
+            "FAILED history의 failureType이 올바르지 않습니다.",
+            EnumSet.of(
+                    ReviewRequestInboxFailureType.NON_RETRYABLE,
+                    ReviewRequestInboxFailureType.RETRY_EXHAUSTED
+            )
+    ));
+
+    private final HistoryValidationRule historyValidationRule;
+
+    ReviewRequestInboxStatus(HistoryValidationRule historyValidationRule) {
+        this.historyValidationRule = historyValidationRule;
+    }
+
+    public void validateHistoryStatus() {
+        historyValidationRule.validateStatus();
+    }
+
+    public void validateHistoryFailure(BoxFailureSnapshot<ReviewRequestInboxFailureType> failure) {
+        historyValidationRule.validateFailure(failure);
+    }
+
+    private static HistoryValidationRule notCompleted() {
+        return new HistoryValidationRule(
+                () -> {
+                    throw new IllegalArgumentException("history status는 완료된 상태여야 합니다.");
+                },
+                failure -> { }
+        );
+    }
+
+    private static HistoryValidationRule requiresNoFailure(String message) {
+        return new HistoryValidationRule(
+                () -> { },
+                failure -> {
+                    validateFailureNotNull(failure);
+                    if (failure.isPresent()) {
+                        throw new IllegalArgumentException(message);
+                    }
+                }
+        );
+    }
+
+    private static HistoryValidationRule requiresFailureType(
+            String invalidFailureTypeMessage,
+            Set<ReviewRequestInboxFailureType> allowedFailureTypes
+    ) {
+        return new HistoryValidationRule(
+                () -> { },
+                failure -> {
+                    validateFailureNotNull(failure);
+                    if (!failure.isPresent()) {
+                        throw new IllegalArgumentException("완료 실패 정보는 비어 있을 수 없습니다.");
+                    }
+
+                    ReviewRequestInboxFailureType failureType = failure.type();
+                    if (!allowedFailureTypes.contains(failureType)) {
+                        throw new IllegalArgumentException(invalidFailureTypeMessage);
+                    }
+                }
+        );
+    }
+
+    private static void validateFailureNotNull(BoxFailureSnapshot<ReviewRequestInboxFailureType> failure) {
+        if (failure == null) {
+            throw new IllegalArgumentException("failure는 비어 있을 수 없습니다.");
+        }
+    }
+
+    private record HistoryValidationRule(
+            Runnable statusValidator,
+            HistoryFailureValidator failureValidator
+    ) {
+
+        private void validateStatus() {
+            statusValidator.run();
+        }
+
+        private void validateFailure(BoxFailureSnapshot<ReviewRequestInboxFailureType> failure) {
+            validateStatus();
+            failureValidator.validate(failure);
+        }
+    }
+
+    @FunctionalInterface
+    private interface HistoryFailureValidator {
+
+        void validate(BoxFailureSnapshot<ReviewRequestInboxFailureType> failure);
+    }
 }

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/JpaReviewRequestInboxHistoryRepository.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/JpaReviewRequestInboxHistoryRepository.java
@@ -1,8 +1,15 @@
 package com.slack.bot.infrastructure.review.persistence.box.in;
 
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxHistory;
+import java.util.List;
 import org.springframework.data.repository.ListCrudRepository;
 
 public interface JpaReviewRequestInboxHistoryRepository
-        extends ListCrudRepository<ReviewRequestInboxHistory, Long> {
+        extends ListCrudRepository<ReviewRequestInboxHistoryJpaEntity, Long> {
+
+    default List<ReviewRequestInboxHistory> findAllDomains() {
+        return findAll().stream()
+                        .map(history -> history.toDomain())
+                        .toList();
+    }
 }

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/JpaReviewRequestInboxRepository.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/JpaReviewRequestInboxRepository.java
@@ -1,7 +1,19 @@
 package com.slack.bot.infrastructure.review.persistence.box.in;
 
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.repository.ListCrudRepository;
 
-public interface JpaReviewRequestInboxRepository extends ListCrudRepository<ReviewRequestInbox, Long> {
+public interface JpaReviewRequestInboxRepository extends ListCrudRepository<ReviewRequestInboxJpaEntity, Long> {
+
+    default Optional<ReviewRequestInbox> findDomainById(Long id) {
+        return findById(id).map(inbox -> inbox.toDomain());
+    }
+
+    default List<ReviewRequestInbox> findAllDomains() {
+        return findAll().stream()
+                        .map(inbox -> inbox.toDomain())
+                        .toList();
+    }
 }

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxHistoryJpaEntity.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxHistoryJpaEntity.java
@@ -1,0 +1,56 @@
+package com.slack.bot.infrastructure.review.persistence.box.in;
+
+import com.slack.bot.domain.common.BaseTimeEntity;
+import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
+import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxHistory;
+import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "review_request_inbox_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewRequestInboxHistoryJpaEntity extends BaseTimeEntity {
+
+    private Long inboxId;
+
+    private int processingAttempt;
+
+    @Enumerated(EnumType.STRING)
+    private ReviewRequestInboxStatus status;
+
+    private Instant completedAt;
+
+    private String failureReason;
+
+    @Enumerated(EnumType.STRING)
+    private ReviewRequestInboxFailureType failureType;
+
+    public ReviewRequestInboxHistory toDomain() {
+        return ReviewRequestInboxHistory.rehydrate(
+                getId(),
+                inboxId,
+                processingAttempt,
+                status,
+                completedAt,
+                failureReason,
+                failureType
+        );
+    }
+
+    public void apply(ReviewRequestInboxHistory history) {
+        this.inboxId = history.getInboxId();
+        this.processingAttempt = history.getProcessingAttempt();
+        this.status = history.getStatus();
+        this.completedAt = history.getCompletedAt();
+        this.failureReason = history.getFailureReason();
+        this.failureType = history.getFailureType();
+    }
+}

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxHistoryJpaEntity.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxHistoryJpaEntity.java
@@ -1,6 +1,7 @@
 package com.slack.bot.infrastructure.review.persistence.box.in;
 
 import com.slack.bot.domain.common.BaseTimeEntity;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxHistory;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
@@ -40,8 +41,7 @@ public class ReviewRequestInboxHistoryJpaEntity extends BaseTimeEntity {
                 processingAttempt,
                 status,
                 completedAt,
-                failureReason,
-                failureType
+                toFailure()
         );
     }
 
@@ -50,7 +50,30 @@ public class ReviewRequestInboxHistoryJpaEntity extends BaseTimeEntity {
         this.processingAttempt = history.getProcessingAttempt();
         this.status = history.getStatus();
         this.completedAt = history.getCompletedAt();
-        this.failureReason = history.getFailureReason();
-        this.failureType = history.getFailureType();
+        applyFailure(history);
+    }
+
+    private void applyFailure(ReviewRequestInboxHistory history) {
+        this.failureReason = null;
+        this.failureType = null;
+
+        BoxFailureSnapshot<ReviewRequestInboxFailureType> failure = history.getFailure();
+        if (!failure.isPresent()) {
+            return;
+        }
+
+        this.failureReason = failure.reason();
+        this.failureType = failure.type();
+    }
+
+    private BoxFailureSnapshot<ReviewRequestInboxFailureType> toFailure() {
+        if (failureReason == null && failureType == null) {
+            return BoxFailureSnapshot.absent();
+        }
+        if (failureReason == null || failureType == null) {
+            throw new IllegalStateException("history failure 상태가 올바르지 않습니다.");
+        }
+
+        return BoxFailureSnapshot.present(failureReason, failureType);
     }
 }

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxJpaEntity.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxJpaEntity.java
@@ -1,6 +1,9 @@
 package com.slack.bot.infrastructure.review.persistence.box.in;
 
 import com.slack.bot.domain.common.BaseTimeEntity;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
@@ -55,11 +58,10 @@ public class ReviewRequestInboxJpaEntity extends BaseTimeEntity {
                 availableAt,
                 status,
                 processingAttempt,
-                processingStartedAt,
-                processedAt,
-                failedAt,
-                failureReason,
-                failureType
+                toProcessingLease(),
+                toProcessedTime(),
+                toFailedTime(),
+                toFailure()
         );
     }
 
@@ -71,10 +73,78 @@ public class ReviewRequestInboxJpaEntity extends BaseTimeEntity {
         this.availableAt = inbox.getAvailableAt();
         this.status = inbox.getStatus();
         this.processingAttempt = inbox.getProcessingAttempt();
-        this.processingStartedAt = inbox.getProcessingStartedAt();
-        this.processedAt = inbox.getProcessedAt();
-        this.failedAt = inbox.getFailedAt();
-        this.failureReason = inbox.getFailureReason();
-        this.failureType = inbox.getFailureType();
+        applyProcessingLease(inbox);
+        applyProcessedTime(inbox);
+        applyFailedTime(inbox);
+        applyFailure(inbox);
+    }
+
+    private void applyProcessingLease(ReviewRequestInbox inbox) {
+        this.processingStartedAt = null;
+        if (inbox.getProcessingLease().isClaimed()) {
+            this.processingStartedAt = inbox.getProcessingLease().startedAt();
+        }
+    }
+
+    private void applyProcessedTime(ReviewRequestInbox inbox) {
+        this.processedAt = null;
+        if (inbox.getProcessedTime().isPresent()) {
+            this.processedAt = inbox.getProcessedTime().occurredAt();
+        }
+    }
+
+    private void applyFailedTime(ReviewRequestInbox inbox) {
+        this.failedAt = null;
+        if (inbox.getFailedTime().isPresent()) {
+            this.failedAt = inbox.getFailedTime().occurredAt();
+        }
+    }
+
+    private void applyFailure(ReviewRequestInbox inbox) {
+        this.failureReason = null;
+        this.failureType = null;
+
+        BoxFailureSnapshot<ReviewRequestInboxFailureType> failure = inbox.getFailure();
+        if (!failure.isPresent()) {
+            return;
+        }
+
+        this.failureReason = failure.reason();
+        this.failureType = failure.type();
+    }
+
+    private BoxProcessingLease toProcessingLease() {
+        if (processingStartedAt == null) {
+            return BoxProcessingLease.idle();
+        }
+
+        return BoxProcessingLease.claimed(processingStartedAt);
+    }
+
+    private BoxEventTime toProcessedTime() {
+        if (processedAt == null) {
+            return BoxEventTime.absent();
+        }
+
+        return BoxEventTime.present(processedAt);
+    }
+
+    private BoxEventTime toFailedTime() {
+        if (failedAt == null) {
+            return BoxEventTime.absent();
+        }
+
+        return BoxEventTime.present(failedAt);
+    }
+
+    private BoxFailureSnapshot<ReviewRequestInboxFailureType> toFailure() {
+        if (failureReason == null && failureType == null) {
+            return BoxFailureSnapshot.absent();
+        }
+        if (failureReason == null || failureType == null) {
+            throw new IllegalStateException("failure 상태가 올바르지 않습니다.");
+        }
+
+        return BoxFailureSnapshot.present(failureReason, failureType);
     }
 }

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxJpaEntity.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxJpaEntity.java
@@ -1,0 +1,80 @@
+package com.slack.bot.infrastructure.review.persistence.box.in;
+
+import com.slack.bot.domain.common.BaseTimeEntity;
+import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
+import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
+import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "review_request_inbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewRequestInboxJpaEntity extends BaseTimeEntity {
+
+    private String idempotencyKey;
+
+    private String apiKey;
+
+    private Long githubPullRequestId;
+
+    private String requestJson;
+
+    private Instant availableAt;
+
+    @Enumerated(EnumType.STRING)
+    private ReviewRequestInboxStatus status;
+
+    private int processingAttempt;
+
+    private Instant processingStartedAt;
+
+    private Instant processedAt;
+
+    private Instant failedAt;
+
+    private String failureReason;
+
+    @Enumerated(EnumType.STRING)
+    private ReviewRequestInboxFailureType failureType;
+
+    public ReviewRequestInbox toDomain() {
+        return ReviewRequestInbox.rehydrate(
+                getId(),
+                idempotencyKey,
+                apiKey,
+                githubPullRequestId,
+                requestJson,
+                availableAt,
+                status,
+                processingAttempt,
+                processingStartedAt,
+                processedAt,
+                failedAt,
+                failureReason,
+                failureType
+        );
+    }
+
+    public void apply(ReviewRequestInbox inbox) {
+        this.idempotencyKey = inbox.getIdempotencyKey();
+        this.apiKey = inbox.getApiKey();
+        this.githubPullRequestId = inbox.getGithubPullRequestId();
+        this.requestJson = inbox.getRequestJson();
+        this.availableAt = inbox.getAvailableAt();
+        this.status = inbox.getStatus();
+        this.processingAttempt = inbox.getProcessingAttempt();
+        this.processingStartedAt = inbox.getProcessingStartedAt();
+        this.processedAt = inbox.getProcessedAt();
+        this.failedAt = inbox.getFailedAt();
+        this.failureReason = inbox.getFailureReason();
+        this.failureType = inbox.getFailureType();
+    }
+}

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapter.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapter.java
@@ -1,7 +1,5 @@
 package com.slack.bot.infrastructure.review.persistence.box.in;
 
-import static com.slack.bot.infrastructure.review.box.in.QReviewRequestInbox.reviewRequestInbox;
-
 import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
@@ -216,7 +214,7 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
     @Override
     @Transactional(readOnly = true)
     public Optional<ReviewRequestInbox> findById(Long inboxId) {
-        return reviewRequestInboxJpaRepository.findById(inboxId);
+        return reviewRequestInboxJpaRepository.findDomainById(inboxId);
     }
 
     @Override
@@ -410,7 +408,7 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
             ReviewRequestInbox inbox,
             Instant claimedProcessingStartedAt
     ) {
-        return saveIfProcessingLeaseMatched(inbox, null, claimedProcessingStartedAt);
+        return saveIfProcessingLeaseMatched(inbox, Optional.empty(), claimedProcessingStartedAt);
     }
 
     @Override
@@ -418,6 +416,14 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
     public boolean saveIfProcessingLeaseMatched(
             ReviewRequestInbox inbox,
             ReviewRequestInboxHistory history,
+            Instant claimedProcessingStartedAt
+    ) {
+        return saveIfProcessingLeaseMatched(inbox, Optional.of(history), claimedProcessingStartedAt);
+    }
+
+    private boolean saveIfProcessingLeaseMatched(
+            ReviewRequestInbox inbox,
+            Optional<ReviewRequestInboxHistory> history,
             Instant claimedProcessingStartedAt
     ) {
         validateSaveIfProcessingLeaseMatchedArguments(inbox, claimedProcessingStartedAt);
@@ -454,9 +460,8 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
             return false;
         }
 
-        if (history != null) {
-            reviewRequestInboxHistoryJpaRepository.save(history.bindInboxId(inbox.getId()));
-        }
+        history.map(historyEntry -> historyEntry.bindInboxId(inbox.getId()))
+               .ifPresent(this::saveHistory);
 
         return true;
     }
@@ -464,7 +469,9 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
     @Override
     @Transactional
     public ReviewRequestInbox save(ReviewRequestInbox inbox) {
-        return reviewRequestInboxJpaRepository.save(inbox);
+        ReviewRequestInboxJpaEntity entity = findInboxEntity(inbox.getId()).orElseGet(ReviewRequestInboxJpaEntity::new);
+        entity.apply(inbox);
+        return reviewRequestInboxJpaRepository.save(entity).toDomain();
     }
 
     protected String buildUpsertPendingSql() {
@@ -662,5 +669,19 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
 
     private String resolveFailureTypeName(ReviewRequestInbox inbox) {
         return inbox.getFailureType().name();
+    }
+
+    private Optional<ReviewRequestInboxJpaEntity> findInboxEntity(Long inboxId) {
+        if (inboxId == null) {
+            return Optional.empty();
+        }
+
+        return reviewRequestInboxJpaRepository.findById(inboxId);
+    }
+
+    private void saveHistory(ReviewRequestInboxHistory history) {
+        ReviewRequestInboxHistoryJpaEntity entity = new ReviewRequestInboxHistoryJpaEntity();
+        entity.apply(history);
+        reviewRequestInboxHistoryJpaRepository.save(entity);
     }
 }

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapter.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapter.java
@@ -1,6 +1,8 @@
 package com.slack.bot.infrastructure.review.persistence.box.in;
 
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxHistory;
@@ -63,11 +65,11 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
                 .addValue("availableAt", Timestamp.from(inbox.getAvailableAt()))
                 .addValue("pendingStatus", ReviewRequestInboxStatus.PENDING.name())
                 .addValue("retryPendingStatus", ReviewRequestInboxStatus.RETRY_PENDING.name())
-                .addValue("noProcessingStartedAt", Timestamp.from(FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT))
-                .addValue("noProcessedAt", Timestamp.from(FailureSnapshotDefaults.NO_PROCESSED_AT))
-                .addValue("noFailureAt", Timestamp.from(FailureSnapshotDefaults.NO_FAILURE_AT))
-                .addValue("noFailureReason", FailureSnapshotDefaults.NO_FAILURE_REASON)
-                .addValue("noneFailureType", ReviewRequestInboxFailureType.NONE.name());
+                .addValue("noProcessingStartedAt", null)
+                .addValue("noProcessedAt", null)
+                .addValue("noFailureAt", null)
+                .addValue("noFailureReason", null)
+                .addValue("noneFailureType", null);
 
         namedParameterJdbcTemplate.update(
                 buildUpsertPendingSql(),
@@ -122,12 +124,12 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
                         failure_reason = :noFailureReason,
                         failure_type = :noneFailureType
                     WHERE id = :inboxId
-                    """,
+                """,
                 updateParameters
-                        .addValue("noProcessedAt", Timestamp.from(FailureSnapshotDefaults.NO_PROCESSED_AT))
-                        .addValue("noFailureAt", Timestamp.from(FailureSnapshotDefaults.NO_FAILURE_AT))
-                        .addValue("noFailureReason", FailureSnapshotDefaults.NO_FAILURE_REASON)
-                        .addValue("noneFailureType", ReviewRequestInboxFailureType.NONE.name())
+                        .addValue("noProcessedAt", null)
+                        .addValue("noFailureAt", null)
+                        .addValue("noFailureReason", null)
+                        .addValue("noneFailureType", null)
         );
         if (updatedCount == 0) {
             return Optional.empty();
@@ -261,7 +263,7 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
                     failure_reason = :failureReason,
                     failure_type = CASE
                         WHEN processing_attempt >= :maxAttempts THEN :retryExhaustedFailureType
-                        ELSE :noneFailureType
+                        ELSE :processingTimeoutFailureType
                     END
                 WHERE id IN (:inboxIds)
                   AND status = :processingStatus
@@ -272,12 +274,12 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
                         .addValue("failedStatus", ReviewRequestInboxStatus.FAILED.name())
                         .addValue("retryPendingStatus", ReviewRequestInboxStatus.RETRY_PENDING.name())
                         .addValue("recoveryUpdatedAt", Timestamp.valueOf(recoveryUpdatedAt))
-                        .addValue("noProcessingStartedAt", Timestamp.from(FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT))
-                        .addValue("noProcessedAt", Timestamp.from(FailureSnapshotDefaults.NO_PROCESSED_AT))
+                        .addValue("noProcessingStartedAt", null)
+                        .addValue("noProcessedAt", null)
                         .addValue("failedAt", Timestamp.from(failedAt))
                         .addValue("failureReason", failureReason)
                         .addValue("retryExhaustedFailureType", ReviewRequestInboxFailureType.RETRY_EXHAUSTED.name())
-                        .addValue("noneFailureType", ReviewRequestInboxFailureType.NONE.name())
+                        .addValue("processingTimeoutFailureType", ReviewRequestInboxFailureType.PROCESSING_TIMEOUT.name())
                         .addValue("inboxIds", inboxIds)
                         .addValue("processingStatus", ReviewRequestInboxStatus.PROCESSING.name())
                         .addValue("processingStartedBefore", Timestamp.from(processingStartedBefore))
@@ -430,10 +432,10 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
 
         MapSqlParameterSource parameters = new MapSqlParameterSource()
                 .addValue("status", inbox.getStatus().name())
-                .addValue("processingStartedAt", toTimestamp(inbox.getProcessingStartedAt()))
-                .addValue("processedAt", toTimestamp(inbox.getProcessedAt()))
-                .addValue("failedAt", toTimestamp(inbox.getFailedAt()))
-                .addValue("failureReason", inbox.getFailureReason())
+                .addValue("processingStartedAt", toTimestamp(inbox.getProcessingLease()))
+                .addValue("processedAt", toTimestamp(inbox.getProcessedTime()))
+                .addValue("failedAt", toTimestamp(inbox.getFailedTime()))
+                .addValue("failureReason", resolveFailureReason(inbox))
                 .addValue("failureType", resolveFailureTypeName(inbox))
                 .addValue("inboxId", inbox.getId())
                 .addValue("processingStatus", ReviewRequestInboxStatus.PROCESSING.name())
@@ -663,12 +665,38 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
         validateProcessingStartedAt(claimedProcessingStartedAt);
     }
 
-    private Timestamp toTimestamp(Instant instant) {
-        return Timestamp.from(instant);
+    private Timestamp toTimestamp(BoxProcessingLease processingLease) {
+        if (!processingLease.isClaimed()) {
+            return null;
+        }
+
+        return Timestamp.from(processingLease.startedAt());
+    }
+
+    private Timestamp toTimestamp(BoxEventTime eventTime) {
+        if (!eventTime.isPresent()) {
+            return null;
+        }
+
+        return Timestamp.from(eventTime.occurredAt());
+    }
+
+    private String resolveFailureReason(ReviewRequestInbox inbox) {
+        BoxFailureSnapshot<ReviewRequestInboxFailureType> failure = inbox.getFailure();
+        if (!failure.isPresent()) {
+            return null;
+        }
+
+        return failure.reason();
     }
 
     private String resolveFailureTypeName(ReviewRequestInbox inbox) {
-        return inbox.getFailureType().name();
+        BoxFailureSnapshot<ReviewRequestInboxFailureType> failure = inbox.getFailure();
+        if (!failure.isPresent()) {
+            return null;
+        }
+
+        return failure.type().name();
     }
 
     private Optional<ReviewRequestInboxJpaEntity> findInboxEntity(Long inboxId) {

--- a/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapter.java
+++ b/src/main/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapter.java
@@ -463,7 +463,7 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
         }
 
         history.map(historyEntry -> historyEntry.bindInboxId(inbox.getId()))
-               .ifPresent(this::saveHistory);
+               .ifPresent(historyEntry -> saveHistory(historyEntry));
 
         return true;
     }
@@ -471,7 +471,9 @@ public class ReviewRequestInboxRepositoryAdapter implements ReviewRequestInboxRe
     @Override
     @Transactional
     public ReviewRequestInbox save(ReviewRequestInbox inbox) {
-        ReviewRequestInboxJpaEntity entity = findInboxEntity(inbox.getId()).orElseGet(ReviewRequestInboxJpaEntity::new);
+        ReviewRequestInboxJpaEntity entity = findInboxEntity(inbox.getId()).orElseGet(
+                () -> new ReviewRequestInboxJpaEntity()
+        );
         entity.apply(inbox);
         return reviewRequestInboxJpaRepository.save(entity).toDomain();
     }

--- a/src/test/java/com/slack/bot/application/IntegrationTestConfig.java
+++ b/src/test/java/com/slack/bot/application/IntegrationTestConfig.java
@@ -48,13 +48,7 @@ public class IntegrationTestConfig {
                                            .baseUrl(baseUrl)
                                            .build();
 
-        return new MemberConnectionSlackApiClient(slackClient) {
-
-            @Override
-            public String resolveUserName(String token, String slackUserId) {
-                return "신규 사용자";
-            }
-        };
+        return new StubMemberConnectionSlackApiClient(slackClient);
     }
 
     @Bean
@@ -65,25 +59,7 @@ public class IntegrationTestConfig {
                                            .baseUrl(baseUrl)
                                            .build();
 
-        return new SlackEventApiClient(slackClient) {
-
-            @Override
-            public ChannelNameWrapper fetchChannelInfo(String token, String channelId) {
-                if ("error-channel-id".equals(channelId)) {
-                    throw new RuntimeException("테스트를 위한 실패");
-                }
-
-                return new ChannelNameWrapper("integration-test-channel");
-            }
-
-            @Override
-            public void sendMessage(String token, String channelId, String text) {
-            }
-
-            @Override
-            public void sendEphemeralMessage(String token, String channelId, String targetUserId, String text) {
-            }
-        };
+        return new StubSlackEventApiClient(slackClient);
     }
 
     @Bean
@@ -94,18 +70,7 @@ public class IntegrationTestConfig {
                                            .build();
         ObjectMapper objectMapper = new ObjectMapper();
 
-        return new ReviewSlackApiClient(slackClient, objectMapper) {
-
-            @Override
-            public void sendBlockMessage(
-                    String token,
-                    String channelId,
-                    JsonNode blocks,
-                    JsonNode attachments,
-                    String fallbackText
-            ) {
-            }
-        };
+        return new StubReviewSlackApiClient(slackClient, objectMapper);
     }
 
     @Bean
@@ -125,41 +90,7 @@ public class IntegrationTestConfig {
     @Bean
     @Primary
     public MysqlDuplicateKeyDetector mysqlDuplicateKeyDetector() {
-        return new MysqlDuplicateKeyDetector() {
-
-            @Override
-            public boolean isDuplicateKey(Throwable throwable) {
-                if (isH2DuplicateKey(throwable)) {
-                    return true;
-                }
-                return super.isDuplicateKey(throwable);
-            }
-
-            private boolean isH2DuplicateKey(Throwable throwable) {
-                Throwable current = throwable;
-
-                while (current != null) {
-                    if (current instanceof ConstraintViolationException cve && isH2SqlState(cve.getSQLException())) {
-                        return true;
-                    }
-
-                    if (current instanceof SQLException sqlException && isH2SqlState(sqlException)) {
-                        return true;
-                    }
-
-                    current = current.getCause();
-                }
-
-                return false;
-            }
-
-            private boolean isH2SqlState(SQLException sqlException) {
-                if (sqlException == null) {
-                    return false;
-                }
-                return "23505".equals(sqlException.getSQLState());
-            }
-        };
+        return new H2AwareMysqlDuplicateKeyDetector();
     }
 
     @Bean
@@ -216,5 +147,96 @@ public class IntegrationTestConfig {
                 repository,
                 historyRepository
         );
+    }
+
+    private static final class StubMemberConnectionSlackApiClient extends MemberConnectionSlackApiClient {
+
+        private StubMemberConnectionSlackApiClient(RestClient slackClient) {
+            super(slackClient);
+        }
+
+        @Override
+        public String resolveUserName(String token, String slackUserId) {
+            return "신규 사용자";
+        }
+    }
+
+    private static final class StubSlackEventApiClient extends SlackEventApiClient {
+
+        private StubSlackEventApiClient(RestClient slackClient) {
+            super(slackClient);
+        }
+
+        @Override
+        public ChannelNameWrapper fetchChannelInfo(String token, String channelId) {
+            if (ERROR_CHANNEL_NAME.equals(channelId)) {
+                throw new RuntimeException("테스트를 위한 실패");
+            }
+
+            return new ChannelNameWrapper("integration-test-channel");
+        }
+
+        @Override
+        public void sendMessage(String token, String channelId, String text) {
+        }
+
+        @Override
+        public void sendEphemeralMessage(String token, String channelId, String targetUserId, String text) {
+        }
+    }
+
+    private static final class StubReviewSlackApiClient extends ReviewSlackApiClient {
+
+        private StubReviewSlackApiClient(RestClient slackClient, ObjectMapper objectMapper) {
+            super(slackClient, objectMapper);
+        }
+
+        @Override
+        public void sendBlockMessage(
+                String token,
+                String channelId,
+                JsonNode blocks,
+                JsonNode attachments,
+                String fallbackText
+        ) {
+        }
+    }
+
+    private static final class H2AwareMysqlDuplicateKeyDetector extends MysqlDuplicateKeyDetector {
+
+        @Override
+        public boolean isDuplicateKey(Throwable throwable) {
+            if (isH2DuplicateKey(throwable)) {
+                return true;
+            }
+
+            return super.isDuplicateKey(throwable);
+        }
+
+        private boolean isH2DuplicateKey(Throwable throwable) {
+            Throwable current = throwable;
+
+            while (current != null) {
+                if (current instanceof ConstraintViolationException cve && isH2SqlState(cve.getSQLException())) {
+                    return true;
+                }
+
+                if (current instanceof SQLException sqlException && isH2SqlState(sqlException)) {
+                    return true;
+                }
+
+                current = current.getCause();
+            }
+
+            return false;
+        }
+
+        private boolean isH2SqlState(SQLException sqlException) {
+            if (sqlException == null) {
+                return false;
+            }
+
+            return "23505".equals(sqlException.getSQLState());
+        }
     }
 }

--- a/src/test/java/com/slack/bot/application/interaction/box/retry/EqualJitterExponentialBackOffPolicyTest.java
+++ b/src/test/java/com/slack/bot/application/interaction/box/retry/EqualJitterExponentialBackOffPolicyTest.java
@@ -163,9 +163,9 @@ class EqualJitterExponentialBackOffPolicyTest {
         AtomicLong initialInterval = new AtomicLong(100L);
         AtomicLong maxInterval = new AtomicLong(1_000L);
         AtomicInteger multiplierScale = new AtomicInteger(20);
-        backOffPolicy.initialIntervalSupplier(initialInterval::get);
+        backOffPolicy.initialIntervalSupplier(() -> initialInterval.get());
         backOffPolicy.multiplierSupplier(() -> multiplierScale.get() / 10.0d);
-        backOffPolicy.maxIntervalSupplier(maxInterval::get);
+        backOffPolicy.maxIntervalSupplier(() -> maxInterval.get());
         backOffPolicy.setSleeper(sleeper);
         BackOffContext backOffContext = backOffPolicy.start(null);
 

--- a/src/test/java/com/slack/bot/application/interaction/client/ReviewReminderSlackDirectMessageClientTest.java
+++ b/src/test/java/com/slack/bot/application/interaction/client/ReviewReminderSlackDirectMessageClientTest.java
@@ -321,16 +321,25 @@ class ReviewReminderSlackDirectMessageClientTest {
                   .andExpect(method(POST))
                   .andExpect(header("Authorization", "Bearer " + token))
                   .andRespond(request -> withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-                          .body(new InputStreamResource(new InputStream() {
-                              @Override
-                              public int read() throws IOException {
-                                  throw new IOException("boom");
-                              }
-                          }))
+                          .body(new InputStreamResource(new FailingInputStream("boom")))
                           .createResponse(request));
 
         assertThatThrownBy(() -> slackDirectMessageClient.send(token, userId, "message"))
                 .isInstanceOf(SlackDmException.class)
                 .hasMessageNotContaining("body=");
+    }
+
+    private static final class FailingInputStream extends InputStream {
+
+        private final String message;
+
+        private FailingInputStream(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public int read() throws IOException {
+            throw new IOException(message);
+        }
     }
 }

--- a/src/test/java/com/slack/bot/application/review/box/ReviewNotificationIdempotencyKeyGeneratorTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/ReviewNotificationIdempotencyKeyGeneratorTest.java
@@ -37,17 +37,21 @@ class ReviewNotificationIdempotencyKeyGeneratorTest {
     @Test
     void SHA_256_알고리즘을_얻지_못하면_IllegalStateException을_던진다() {
         // given
-        ReviewNotificationIdempotencyKeyGenerator failingGenerator = new ReviewNotificationIdempotencyKeyGenerator() {
-            @Override
-            MessageDigest messageDigest() throws NoSuchAlgorithmException {
-                throw new NoSuchAlgorithmException("not supported");
-            }
-        };
+        ReviewNotificationIdempotencyKeyGenerator failingGenerator = new FailingReviewNotificationIdempotencyKeyGenerator();
 
         // when // then
         assertThatThrownBy(() -> failingGenerator.generate(ReviewNotificationIdempotencyScope.REVIEW_NOTIFICATION_OUTBOX, "payload"))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("SHA-256 알고리즘을 사용할 수 없습니다.")
                 .hasCauseInstanceOf(NoSuchAlgorithmException.class);
+    }
+
+    private static final class FailingReviewNotificationIdempotencyKeyGenerator
+            extends ReviewNotificationIdempotencyKeyGenerator {
+
+        @Override
+        MessageDigest messageDigest() throws NoSuchAlgorithmException {
+            throw new NoSuchAlgorithmException("not supported");
+        }
     }
 }

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorTest.java
@@ -82,7 +82,7 @@ class ReviewRequestInboxEntryProcessorTest {
                 .isInstanceOf(ReviewRequestInboxProcessingLeaseLostException.class)
                 .hasMessageContaining("processing lease");
 
-        ReviewRequestInbox actualInbox = jpaReviewRequestInboxRepository.findById(inbox.getId()).orElseThrow();
+        ReviewRequestInbox actualInbox = jpaReviewRequestInboxRepository.findDomainById(inbox.getId()).orElseThrow();
         List<ReviewNotificationOutbox> actualOutboxes = jpaReviewNotificationOutboxRepository.findAll();
 
         assertAll(
@@ -104,7 +104,7 @@ class ReviewRequestInboxEntryProcessorTest {
         ReflectionTestUtils.setField(inbox, "processingStartedAt", CLAIMED_PROCESSING_STARTED_AT);
         ReflectionTestUtils.setField(inbox, "processedAt", FailureSnapshotDefaults.NO_PROCESSED_AT);
         ReflectionTestUtils.setField(inbox, "processingAttempt", 1);
-        return jpaReviewRequestInboxRepository.save(inbox);
+        return reviewRequestInboxRepository.save(inbox);
     }
 
     private ReviewNotificationPayload request(Long githubPullRequestId, String pullRequestTitle) {

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorTest.java
@@ -11,7 +11,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slack.bot.application.IntegrationTest;
 import com.slack.bot.application.review.box.in.exception.ReviewRequestInboxProcessingLeaseLostException;
 import com.slack.bot.application.review.dto.ReviewNotificationPayload;
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
 import com.slack.bot.infrastructure.review.box.in.repository.ReviewRequestInboxRepository;
@@ -101,8 +103,10 @@ class ReviewRequestInboxEntryProcessorTest {
                 Instant.parse("2026-02-15T00:00:00Z")
         );
         ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
-        ReflectionTestUtils.setField(inbox, "processingStartedAt", CLAIMED_PROCESSING_STARTED_AT);
-        ReflectionTestUtils.setField(inbox, "processedAt", FailureSnapshotDefaults.NO_PROCESSED_AT);
+        ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.claimed(CLAIMED_PROCESSING_STARTED_AT));
+        ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());
         ReflectionTestUtils.setField(inbox, "processingAttempt", 1);
         return reviewRequestInboxRepository.save(inbox);
     }

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorUnitTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorUnitTest.java
@@ -5,7 +5,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
 import com.slack.bot.infrastructure.review.box.in.repository.ReviewRequestInboxRepository;
@@ -77,6 +79,27 @@ class ReviewRequestInboxEntryProcessorUnitTest {
     }
 
     @Test
+    void processingLease가_없으면_트랜잭션_처리를_건너뛴다() {
+        // given
+        ReviewRequestInbox inbox = ReviewRequestInbox.pending(
+                "review-entry-no-lease",
+                "test-api-key",
+                111L,
+                "{}",
+                CLAIMED_PROCESSING_STARTED_AT
+        );
+        ReflectionTestUtils.setField(inbox, "id", 111L);
+        given(reviewRequestInboxRepository.findById(111L)).willReturn(Optional.of(inbox));
+
+        // when
+        reviewRequestInboxEntryProcessor.processClaimedInbox(111L, CLAIMED_PROCESSING_STARTED_AT);
+
+        // then
+        verify(reviewRequestInboxRepository, never()).renewProcessingLease(any(), any(), any());
+        verify(reviewRequestInboxTransactionalProcessor, never()).processInTransaction(any(), any());
+    }
+
+    @Test
     void lease_연장에_실패하면_트랜잭션_처리를_건너뛴다() {
         // given
         ReviewRequestInbox inbox = processingInbox(12L, CLAIMED_PROCESSING_STARTED_AT);
@@ -116,8 +139,10 @@ class ReviewRequestInboxEntryProcessorUnitTest {
         );
         ReflectionTestUtils.setField(inbox, "id", inboxId);
         ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
-        ReflectionTestUtils.setField(inbox, "processingStartedAt", processingStartedAt);
-        ReflectionTestUtils.setField(inbox, "processedAt", FailureSnapshotDefaults.NO_PROCESSED_AT);
+        ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.claimed(processingStartedAt));
+        ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());
         ReflectionTestUtils.setField(inbox, "processingAttempt", 1);
         return inbox;
     }

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorUnitTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxEntryProcessorUnitTest.java
@@ -81,14 +81,7 @@ class ReviewRequestInboxEntryProcessorUnitTest {
     @Test
     void processingLease가_없으면_트랜잭션_처리를_건너뛴다() {
         // given
-        ReviewRequestInbox inbox = ReviewRequestInbox.pending(
-                "review-entry-no-lease",
-                "test-api-key",
-                111L,
-                "{}",
-                CLAIMED_PROCESSING_STARTED_AT
-        );
-        ReflectionTestUtils.setField(inbox, "id", 111L);
+        ReviewRequestInbox inbox = processingInboxWithoutLease(111L);
         given(reviewRequestInboxRepository.findById(111L)).willReturn(Optional.of(inbox));
 
         // when
@@ -140,6 +133,24 @@ class ReviewRequestInboxEntryProcessorUnitTest {
         ReflectionTestUtils.setField(inbox, "id", inboxId);
         ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
         ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.claimed(processingStartedAt));
+        ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());
+        ReflectionTestUtils.setField(inbox, "processingAttempt", 1);
+        return inbox;
+    }
+
+    private ReviewRequestInbox processingInboxWithoutLease(Long inboxId) {
+        ReviewRequestInbox inbox = ReviewRequestInbox.pending(
+                "review-entry-" + inboxId + "-no-lease",
+                "test-api-key",
+                100L + inboxId,
+                "{}",
+                CLAIMED_PROCESSING_STARTED_AT
+        );
+        ReflectionTestUtils.setField(inbox, "id", inboxId);
+        ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
+        ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.idle());
         ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
         ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
         ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxLeaseIntegrationTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxLeaseIntegrationTest.java
@@ -95,7 +95,7 @@ class ReviewRequestInboxLeaseIntegrationTest {
         reviewRequestInboxProcessor.processPending(1);
 
         // then
-        ReviewRequestInbox actualInbox = jpaReviewRequestInboxRepository.findById(inbox.getId()).orElseThrow();
+        ReviewRequestInbox actualInbox = jpaReviewRequestInboxRepository.findDomainById(inbox.getId()).orElseThrow();
         List<ReviewNotificationOutbox> actualOutboxes = jpaReviewNotificationOutboxRepository.findAll();
 
         assertAll(
@@ -129,7 +129,7 @@ class ReviewRequestInboxLeaseIntegrationTest {
         int recoveredCount = reviewRequestInboxProcessor.recoverTimeoutProcessing(60_000L);
 
         // then
-        ReviewRequestInbox actualInbox = jpaReviewRequestInboxRepository.findById(inbox.getId()).orElseThrow();
+        ReviewRequestInbox actualInbox = jpaReviewRequestInboxRepository.findDomainById(inbox.getId()).orElseThrow();
         List<ReviewNotificationOutbox> actualOutboxes = jpaReviewNotificationOutboxRepository.findAll();
 
         assertAll(
@@ -155,7 +155,7 @@ class ReviewRequestInboxLeaseIntegrationTest {
                 requestJson,
                 Instant.parse("2026-03-23T23:59:00Z")
         );
-        return jpaReviewRequestInboxRepository.save(inbox);
+        return reviewRequestInboxRepository.save(inbox);
     }
 
     private ReviewNotificationPayload request(Long githubPullRequestId) {

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxProcessorTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxProcessorTest.java
@@ -111,7 +111,7 @@ class ReviewRequestInboxProcessorTest {
 
         // then
         await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
-            List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAll();
+            List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAllDomains();
             List<ReviewNotificationOutbox> outboxes = jpaReviewNotificationOutboxRepository.findAll();
             ReviewRequestInbox inbox = findOnlyInbox();
 
@@ -147,7 +147,7 @@ class ReviewRequestInboxProcessorTest {
 
         // then
         await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
-            List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAll();
+            List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAllDomains();
             List<ReviewNotificationOutbox> outboxes = jpaReviewNotificationOutboxRepository.findAll();
             ReviewRequestInbox inbox = findOnlyInbox();
 
@@ -207,7 +207,7 @@ class ReviewRequestInboxProcessorTest {
                 Instant.now().minusSeconds(120)
         );
         setProcessingState(inbox, Instant.now().minusSeconds(120), 1);
-        ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+        ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
 
         // when
         reviewRequestInboxProcessor.recoverTimeoutProcessing(1_000);
@@ -215,7 +215,7 @@ class ReviewRequestInboxProcessorTest {
 
         // then
         await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> {
-            ReviewRequestInbox processed = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+            ReviewRequestInbox processed = jpaReviewRequestInboxRepository.findDomainById(saved.getId()).orElseThrow();
             List<ReviewRequestInboxHistory> histories = historiesOf(saved.getId());
 
             assertAll(
@@ -248,13 +248,13 @@ class ReviewRequestInboxProcessorTest {
         setProcessingState(inbox, Instant.now().minusSeconds(120), 1);
         inbox.markRetryPending(Instant.now().minusSeconds(110), "first timeout failure");
         setProcessingState(inbox, Instant.now().minusSeconds(100), 2);
-        ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+        ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
 
         // when
         reviewRequestInboxProcessor.recoverTimeoutProcessing(1_000);
 
         // then
-        ReviewRequestInbox failed = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+        ReviewRequestInbox failed = jpaReviewRequestInboxRepository.findDomainById(saved.getId()).orElseThrow();
         assertAll(
                 () -> assertThat(spyReviewNotificationService.getSendCount()).isZero(),
                 () -> assertThat(failed.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
@@ -299,7 +299,7 @@ class ReviewRequestInboxProcessorTest {
     }
 
     private List<ReviewRequestInboxHistory> historiesOf(Long inboxId) {
-        return jpaReviewRequestInboxHistoryRepository.findAll()
+        return jpaReviewRequestInboxHistoryRepository.findAllDomains()
                                                      .stream()
                                                      .filter(history -> inboxId.equals(history.getInboxId()))
                                                      .sorted(Comparator.comparingInt(history -> history.getProcessingAttempt()))
@@ -358,7 +358,7 @@ class ReviewRequestInboxProcessorTest {
         reviewRequestInboxProcessor.enqueue("test-api-key", second, 0);
 
         // then
-        List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAll();
+        List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAllDomains();
         ReviewRequestInbox inbox = findOnlyInbox();
         assertAll(
                 () -> assertThat(inboxes).hasSize(1),
@@ -475,7 +475,7 @@ class ReviewRequestInboxProcessorTest {
         );
         setProcessingState(inbox, Instant.now().minusSeconds(55), 1);
         inbox.markRetryPending(Instant.now().minusSeconds(50), "first failure");
-        ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+        ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
 
         doThrow(new ResourceAccessException("temporary network issue"))
                 .when(reviewNotificationOutboxEnqueuer)
@@ -491,7 +491,7 @@ class ReviewRequestInboxProcessorTest {
         reviewRequestInboxProcessor.processPending(10);
 
         // then
-        ReviewRequestInbox failed = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+        ReviewRequestInbox failed = jpaReviewRequestInboxRepository.findDomainById(saved.getId()).orElseThrow();
         assertAll(
                 () -> assertThat(failed.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
                 () -> assertThat(failed.getProcessingAttempt()).isEqualTo(2),
@@ -514,7 +514,7 @@ class ReviewRequestInboxProcessorTest {
         reviewRequestInboxProcessor.processPending(10);
 
         // then
-        ReviewRequestInbox reloaded = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+        ReviewRequestInbox reloaded = jpaReviewRequestInboxRepository.findDomainById(saved.getId()).orElseThrow();
         assertAll(
                 () -> assertThat(spyReviewNotificationService.getSendCount()).isZero(),
                 () -> assertThat(reloaded.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
@@ -545,8 +545,8 @@ class ReviewRequestInboxProcessorTest {
         reviewRequestInboxProcessor.processPending(10);
 
         // then
-        ReviewRequestInbox reloadedFirst = jpaReviewRequestInboxRepository.findById(firstInbox.getId()).orElseThrow();
-        ReviewRequestInbox reloadedSecond = jpaReviewRequestInboxRepository.findById(secondInbox.getId()).orElseThrow();
+        ReviewRequestInbox reloadedFirst = jpaReviewRequestInboxRepository.findDomainById(firstInbox.getId()).orElseThrow();
+        ReviewRequestInbox reloadedSecond = jpaReviewRequestInboxRepository.findDomainById(secondInbox.getId()).orElseThrow();
         assertAll(
                 () -> assertThat(reloadedFirst.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
                 () -> assertThat(reloadedSecond.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSED),
@@ -583,13 +583,13 @@ class ReviewRequestInboxProcessorTest {
     }
 
     private ReviewRequestInbox findOnlyInbox() {
-        List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAll();
+        List<ReviewRequestInbox> inboxes = jpaReviewRequestInboxRepository.findAllDomains();
         assertThat(inboxes).hasSize(1);
         return inboxes.getFirst();
     }
 
     private ReviewRequestInbox findInboxByGithubPullRequestId(Long githubPullRequestId) {
-        return jpaReviewRequestInboxRepository.findAll()
+        return jpaReviewRequestInboxRepository.findAllDomains()
                                              .stream()
                                              .filter(inbox -> githubPullRequestId.equals(inbox.getGithubPullRequestId()))
                                              .findFirst()

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxProcessorTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxProcessorTest.java
@@ -20,7 +20,9 @@ import com.slack.bot.application.review.box.out.ReviewNotificationOutboxEnqueuer
 import com.slack.bot.application.review.dto.ReviewNotificationPayload;
 import com.slack.bot.application.worker.PollingHintPublisher;
 import com.slack.bot.application.worker.PollingHintTarget;
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import com.slack.bot.infrastructure.review.batch.SpyReviewNotificationService;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
@@ -122,7 +124,7 @@ class ReviewRequestInboxProcessorTest {
                     () -> assertThat(inbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSED),
                     () -> assertThat(inbox.getProcessingAttempt()).isEqualTo(1),
                     () -> assertThat(inbox.getIdempotencyKey()).hasSize(64),
-                    () -> assertThat(inbox.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
+                    () -> assertThat(inbox.getFailure().isPresent()).isFalse(),
                     () -> assertThat(reviewNotificationSourceContext.currentSourceKey()).isEmpty()
             );
         });
@@ -183,8 +185,8 @@ class ReviewRequestInboxProcessorTest {
                 () -> assertThat(spyReviewNotificationService.getSendCount()).isZero(),
                 () -> assertThat(inbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
                 () -> assertThat(inbox.getProcessingAttempt()).isEqualTo(1),
-                () -> assertThat(inbox.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
-                () -> assertThat(inbox.getFailureReason()).isNotBlank(),
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
+                () -> assertThat(inbox.getFailure().reason()).isNotBlank(),
                 () -> assertThat(reviewNotificationSourceContext.currentSourceKey()).isEmpty()
         );
     }
@@ -222,7 +224,7 @@ class ReviewRequestInboxProcessorTest {
                     () -> assertThat(spyReviewNotificationService.getSendCount()).isEqualTo(1),
                     () -> assertThat(processed.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSED),
                     () -> assertThat(processed.getProcessingAttempt()).isEqualTo(2),
-                    () -> assertThat(processed.getFailureReason()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_REASON),
+                    () -> assertThat(processed.getFailure().isPresent()).isFalse(),
                     () -> assertThat(histories).hasSize(2),
                     () -> assertThat(histories).extracting(history -> history.getStatus())
                             .containsExactly(
@@ -259,8 +261,8 @@ class ReviewRequestInboxProcessorTest {
                 () -> assertThat(spyReviewNotificationService.getSendCount()).isZero(),
                 () -> assertThat(failed.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
                 () -> assertThat(failed.getProcessingAttempt()).isEqualTo(2),
-                () -> assertThat(failed.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.RETRY_EXHAUSTED),
-                () -> assertThat(failed.getFailureReason()).isNotBlank()
+                () -> assertThat(failed.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.RETRY_EXHAUSTED),
+                () -> assertThat(failed.getFailure().reason()).isNotBlank()
         );
     }
 
@@ -450,8 +452,7 @@ class ReviewRequestInboxProcessorTest {
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
                 () -> assertThat(inbox.getProcessingAttempt()).isEqualTo(1),
-                () -> assertThat(inbox.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
-                () -> assertThat(inbox.getFailureReason()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_REASON),
+                () -> assertThat(inbox.getFailure().isPresent()).isFalse(),
                 () -> assertThat(jpaReviewNotificationOutboxRepository.findAll()).isEmpty()
         );
     }
@@ -495,8 +496,7 @@ class ReviewRequestInboxProcessorTest {
         assertAll(
                 () -> assertThat(failed.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
                 () -> assertThat(failed.getProcessingAttempt()).isEqualTo(2),
-                () -> assertThat(failed.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
-                () -> assertThat(failed.getFailureReason()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_REASON),
+                () -> assertThat(failed.getFailure().isPresent()).isFalse(),
                 () -> assertThat(jpaReviewNotificationOutboxRepository.findAll()).isEmpty()
         );
     }
@@ -574,12 +574,11 @@ class ReviewRequestInboxProcessorTest {
 
     private void setProcessingState(ReviewRequestInbox inbox, Instant processingStartedAt, int processingAttempt) {
         ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
-        ReflectionTestUtils.setField(inbox, "processingStartedAt", processingStartedAt);
-        ReflectionTestUtils.setField(inbox, "processedAt", FailureSnapshotDefaults.NO_PROCESSED_AT);
+        ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.claimed(processingStartedAt));
+        ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());
         ReflectionTestUtils.setField(inbox, "processingAttempt", processingAttempt);
-        ReflectionTestUtils.setField(inbox, "failedAt", FailureSnapshotDefaults.NO_FAILURE_AT);
-        ReflectionTestUtils.setField(inbox, "failureReason", FailureSnapshotDefaults.NO_FAILURE_REASON);
-        ReflectionTestUtils.setField(inbox, "failureType", ReviewRequestInboxFailureType.NONE);
     }
 
     private ReviewRequestInbox findOnlyInbox() {

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxProcessorTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxProcessorTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slack.bot.application.IntegrationTest;
 import com.slack.bot.application.review.box.ReviewNotificationSourceContext;
@@ -406,8 +407,7 @@ class ReviewRequestInboxProcessorTest {
     void request_직렬화에_실패하면_enqueue는_예외를_던진다() throws Exception {
         // given
         ReviewNotificationPayload request = request(503L, "serialization-fail");
-        doThrow(new JsonProcessingException("serialize fail") {
-        }).when(objectMapper).writeValueAsString(any());
+        doThrow(new JsonMappingException(null, "serialize fail")).when(objectMapper).writeValueAsString(any());
 
         // when & then
         assertThatThrownBy(() -> reviewRequestInboxProcessor.enqueue("test-api-key", request, 0))

--- a/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxTransactionalProcessorUnitTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/in/ReviewRequestInboxTransactionalProcessorUnitTest.java
@@ -18,7 +18,9 @@ import com.slack.bot.application.review.box.ReviewNotificationSourceContext;
 import com.slack.bot.application.review.box.in.exception.ReviewRequestInboxProcessingLeaseLostException;
 import com.slack.bot.application.review.dto.ReviewNotificationPayload;
 import com.slack.bot.global.config.properties.InteractionRetryProperties;
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxStatus;
@@ -132,7 +134,7 @@ class ReviewRequestInboxTransactionalProcessorUnitTest {
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
                 () -> assertThat(actual.getProcessingAttempt()).isEqualTo(1),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE)
+                () -> assertThat(actual.getFailure().isPresent()).isFalse()
         );
         verify(reviewRequestInboxRepository, never()).save(actual);
         verify(reviewRequestInboxRepository, never()).saveIfProcessingLeaseMatched(any(), any(), any());
@@ -169,9 +171,9 @@ class ReviewRequestInboxTransactionalProcessorUnitTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
-                () -> assertThat(actual.getFailureReason()).isNotBlank(),
-                () -> assertThat(actual.getFailureReason().length()).isLessThanOrEqualTo(500)
+                () -> assertThat(actual.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
+                () -> assertThat(actual.getFailure().reason()).isNotBlank(),
+                () -> assertThat(actual.getFailure().reason().length()).isLessThanOrEqualTo(500)
         );
         verify(reviewRequestInboxRepository).saveIfProcessingLeaseMatched(eq(actual), any(), eq(CLAIMED_PROCESSING_STARTED_AT));
     }
@@ -191,8 +193,8 @@ class ReviewRequestInboxTransactionalProcessorUnitTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
-                () -> assertThat(actual.getFailureReason()).isNotBlank()
+                () -> assertThat(actual.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
+                () -> assertThat(actual.getFailure().reason()).isNotBlank()
         );
         verify(reviewRequestInboxRepository).saveIfProcessingLeaseMatched(eq(actual), any(), eq(CLAIMED_PROCESSING_STARTED_AT));
     }
@@ -213,8 +215,8 @@ class ReviewRequestInboxTransactionalProcessorUnitTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
-                () -> assertThat(actual.getFailureReason()).isNotBlank()
+                () -> assertThat(actual.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.RETRYABLE),
+                () -> assertThat(actual.getFailure().reason()).isNotBlank()
         );
     }
 
@@ -234,8 +236,8 @@ class ReviewRequestInboxTransactionalProcessorUnitTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.RETRY_EXHAUSTED),
-                () -> assertThat(actual.getFailureReason()).isNotBlank()
+                () -> assertThat(actual.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.RETRY_EXHAUSTED),
+                () -> assertThat(actual.getFailure().reason()).isNotBlank()
         );
     }
 
@@ -262,8 +264,7 @@ class ReviewRequestInboxTransactionalProcessorUnitTest {
         // then
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.PENDING),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
-                () -> assertThat(actual.getFailureReason()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_REASON)
+                () -> assertThat(actual.getFailure().isPresent()).isFalse()
         );
     }
 
@@ -322,8 +323,10 @@ class ReviewRequestInboxTransactionalProcessorUnitTest {
 
     private void setProcessingState(ReviewRequestInbox inbox, Instant processingStartedAt, int processingAttempt) {
         ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
-        ReflectionTestUtils.setField(inbox, "processingStartedAt", processingStartedAt);
-        ReflectionTestUtils.setField(inbox, "processedAt", FailureSnapshotDefaults.NO_PROCESSED_AT);
+        ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.claimed(processingStartedAt));
+        ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());
         ReflectionTestUtils.setField(inbox, "processingAttempt", processingAttempt);
     }
 }

--- a/src/test/java/com/slack/bot/application/review/box/out/ReviewNotificationOutboxEnqueuerTest.java
+++ b/src/test/java/com/slack/bot/application/review/box/out/ReviewNotificationOutboxEnqueuerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slack.bot.application.review.box.ReviewNotificationIdempotencyKeyGenerator;
 import com.slack.bot.application.review.dto.ReviewNotificationPayload;
@@ -249,8 +250,7 @@ class ReviewNotificationOutboxEnqueuerTest {
                 List.of("reviewer-gh-1"),
                 List.of("reviewer-gh-1")
         );
-        doThrow(new JsonProcessingException("serialize fail") {
-        }).when(objectMapper).writeValueAsString(payload);
+        doThrow(new JsonMappingException(null, "serialize fail")).when(objectMapper).writeValueAsString(payload);
 
         // when & then
         assertThatThrownBy(() -> failingEnqueuer.enqueueReviewNotification("SOURCE", 1L, "T1", "C1", payload))

--- a/src/test/java/com/slack/bot/application/worker/AdaptivePollingRunnerIntegrationTest.java
+++ b/src/test/java/com/slack/bot/application/worker/AdaptivePollingRunnerIntegrationTest.java
@@ -116,21 +116,7 @@ class AdaptivePollingRunnerIntegrationTest {
         AtomicInteger pollCount = new AtomicInteger();
         CountDownLatch enteredSleep = new CountDownLatch(1);
         Duration pollInterval = Duration.ofSeconds(5L);
-        AdaptivePollingRunner.PollingSleeper pollingSleeper = new AdaptivePollingRunner.PollingSleeper() {
-            private final AdaptivePollingRunner.MonitorPollingSleeper delegate =
-                    new AdaptivePollingRunner.MonitorPollingSleeper();
-
-            @Override
-            public AdaptivePollingRunner.PollingSleepResult sleep(Duration delay) throws InterruptedException {
-                enteredSleep.countDown();
-                return delegate.sleep(delay);
-            }
-
-            @Override
-            public void wakeUp() {
-                delegate.wakeUp();
-            }
-        };
+        AdaptivePollingRunner.PollingSleeper pollingSleeper = new CountingPollingSleeper(enteredSleep);
         AdaptivePollingRunner adaptivePollingRunner = new AdaptivePollingRunner(
                 "db-polling-wakeup",
                 () -> {
@@ -200,5 +186,27 @@ class AdaptivePollingRunnerIntegrationTest {
                                 .put("action_id", actionId)
                                 .put("value", value));
         return actions;
+    }
+
+    private static final class CountingPollingSleeper implements AdaptivePollingRunner.PollingSleeper {
+
+        private final CountDownLatch enteredSleep;
+        private final AdaptivePollingRunner.MonitorPollingSleeper delegate;
+
+        private CountingPollingSleeper(CountDownLatch enteredSleep) {
+            this.enteredSleep = enteredSleep;
+            this.delegate = new AdaptivePollingRunner.MonitorPollingSleeper();
+        }
+
+        @Override
+        public AdaptivePollingRunner.PollingSleepResult sleep(Duration delay) throws InterruptedException {
+            enteredSleep.countDown();
+            return delegate.sleep(delay);
+        }
+
+        @Override
+        public void wakeUp() {
+            delegate.wakeUp();
+        }
     }
 }

--- a/src/test/java/com/slack/bot/infrastructure/interaction/client/NotificationTransportApiClientTest.java
+++ b/src/test/java/com/slack/bot/infrastructure/interaction/client/NotificationTransportApiClientTest.java
@@ -10,8 +10,13 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -668,7 +673,7 @@ class NotificationTransportApiClientTest {
     }
 
     @Test
-    void 모달_view_직렬화_실패시_원인_예외를_포함해_던진다() {
+    void 모달_view_직렬화_실패시_원인_예외를_포함해_던진다() throws Exception {
         // given
         String token = "xoxb-token";
         String triggerId = "TRIGGER_ID";
@@ -676,13 +681,10 @@ class NotificationTransportApiClientTest {
                 .type("modal")
                 .callbackId("review_time_submit")
         );
-        ObjectMapper failingObjectMapper = new ObjectMapper() {
-            @Override
-            public com.fasterxml.jackson.databind.JsonNode readTree(String content) throws JsonProcessingException {
-                throw new JsonProcessingException("readTree failed") {
-                };
-            }
-        };
+        ObjectMapper failingObjectMapper = mock(ObjectMapper.class);
+        willThrow(new JsonMappingException(null, "readTree failed"))
+                .given(failingObjectMapper)
+                .readTree(anyString());
         NotificationTransportApiClient failingClient = new NotificationTransportApiClient(
                 RestClient.builder().baseUrl("https://slack.com/api/").build(),
                 failingObjectMapper
@@ -811,12 +813,7 @@ class NotificationTransportApiClientTest {
                   .andExpect(method(POST))
                   .andExpect(header("Authorization", "Bearer " + token))
                   .andRespond(request -> withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-                          .body(new InputStreamResource(new InputStream() {
-                              @Override
-                              public int read() throws IOException {
-                                  throw new IOException("Stream read failed");
-                              }
-                          }))
+                          .body(new InputStreamResource(new FailingInputStream("Stream read failed")))
                           .createResponse(request));
 
         // when & then
@@ -824,6 +821,20 @@ class NotificationTransportApiClientTest {
                 .isInstanceOf(SlackBotMessageDispatchException.class)
                 .hasMessageContaining("Slack API 요청 실패")
                 .hasMessageContaining("500");
+    }
+
+    private static final class FailingInputStream extends InputStream {
+
+        private final String message;
+
+        private FailingInputStream(String message) {
+            this.message = message;
+        }
+
+        @Override
+        public int read() throws IOException {
+            throw new IOException(message);
+        }
     }
 
     private ArrayNode sectionBlocks() {

--- a/src/test/java/com/slack/bot/infrastructure/review/batch/InMemoryReviewEventBatchTest.java
+++ b/src/test/java/com/slack/bot/infrastructure/review/batch/InMemoryReviewEventBatchTest.java
@@ -140,7 +140,7 @@ class InMemoryReviewEventBatchTest {
 
         // then
         await().atMost(3, SECONDS).untilAsserted(() -> {
-            ReviewRequestInbox inbox = jpaReviewRequestInboxRepository.findAll().getFirst();
+            ReviewRequestInbox inbox = jpaReviewRequestInboxRepository.findAllDomains().getFirst();
 
             assertThat(inbox.getRequestJson())
                     .contains("\"reviewRoundKey\":\"1\"")

--- a/src/test/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxHistoryTest.java
+++ b/src/test/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxHistoryTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -22,15 +22,15 @@ class ReviewRequestInboxHistoryTest {
                 1,
                 ReviewRequestInboxStatus.RETRY_PENDING,
                 Instant.parse("2026-03-27T00:00:00Z"),
-                "failure",
-                ReviewRequestInboxFailureType.NONE
+                BoxFailureSnapshot.present("failure", ReviewRequestInboxFailureType.RETRYABLE)
         );
 
         // then
         assertAll(
                 () -> assertThat(history.getInboxId()).isNull(),
                 () -> assertThat(history.getProcessingAttempt()).isEqualTo(1),
-                () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING)
+                () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
+                () -> assertThat(history.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.RETRYABLE)
         );
     }
 
@@ -42,8 +42,7 @@ class ReviewRequestInboxHistoryTest {
                 1,
                 ReviewRequestInboxStatus.FAILED,
                 Instant.parse("2026-03-27T00:00:00Z"),
-                "failure",
-                ReviewRequestInboxFailureType.NON_RETRYABLE
+                BoxFailureSnapshot.present("failure", ReviewRequestInboxFailureType.NON_RETRYABLE)
         );
 
         // when
@@ -53,7 +52,7 @@ class ReviewRequestInboxHistoryTest {
         assertAll(
                 () -> assertThat(actual.getInboxId()).isEqualTo(10L),
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE)
+                () -> assertThat(actual.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE)
         );
     }
 
@@ -65,8 +64,7 @@ class ReviewRequestInboxHistoryTest {
                 1,
                 ReviewRequestInboxStatus.PROCESSED,
                 Instant.parse("2026-03-27T00:00:00Z"),
-                FailureSnapshotDefaults.NO_FAILURE_REASON,
-                ReviewRequestInboxFailureType.NONE
+                BoxFailureSnapshot.absent()
         );
 
         // when & then
@@ -83,14 +81,30 @@ class ReviewRequestInboxHistoryTest {
                 1,
                 ReviewRequestInboxStatus.RETRY_PENDING,
                 Instant.parse("2026-03-27T00:00:00Z"),
-                "timeout",
-                ReviewRequestInboxFailureType.PROCESSING_TIMEOUT
+                BoxFailureSnapshot.present("timeout", ReviewRequestInboxFailureType.PROCESSING_TIMEOUT)
         );
 
         // then
         assertAll(
                 () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
-                () -> assertThat(history.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT)
+                () -> assertThat(history.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT)
         );
+    }
+
+    @Test
+    void completed는_null_failure을_허용하지_않는다() {
+        // given
+        Instant completedAt = Instant.parse("2026-03-27T00:00:00Z");
+
+        // when & then
+        assertThatThrownBy(() -> ReviewRequestInboxHistory.completed(
+                10L,
+                1,
+                ReviewRequestInboxStatus.FAILED,
+                completedAt,
+                null
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("failure는 비어 있을 수 없습니다.");
     }
 }

--- a/src/test/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxTest.java
+++ b/src/test/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import java.time.Instant;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -16,7 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class ReviewRequestInboxTest {
 
     @Test
-    void pending으로_생성하면_기본값은_PENDING이고_시도횟수는_0이다() {
+    void pending으로_생성하면_기본값은_PENDING이고_상태상세값은_비어있다() {
         // when
         ReviewRequestInbox inbox = pendingInbox();
 
@@ -29,156 +31,57 @@ class ReviewRequestInboxTest {
                 () -> assertThat(inbox.getAvailableAt()).isEqualTo(Instant.parse("2026-02-24T00:00:00Z")),
                 () -> assertThat(inbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.PENDING),
                 () -> assertThat(inbox.getProcessingAttempt()).isZero(),
-                () -> assertThat(inbox.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE)
+                () -> assertThat(inbox.hasClaimedProcessingLease()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailure().isPresent()).isFalse()
         );
     }
 
     @Test
-    void pending은_idempotencyKey가_null이면_예외를_던진다() {
+    void rehydrate는_PROCESSING과_idle_processingLease_조합을_허용하지_않는다() {
         // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        null,
-                        "api-key",
-                        42L,
-                        "{\"githubPullRequestId\":42}",
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
+        assertThatThrownBy(() -> ReviewRequestInbox.rehydrate(
+                1L,
+                "api-key:42",
+                "api-key",
+                42L,
+                "{}",
+                Instant.parse("2026-02-24T00:00:00Z"),
+                ReviewRequestInboxStatus.PROCESSING,
+                1,
+                BoxProcessingLease.idle(),
+                BoxEventTime.absent(),
+                BoxEventTime.absent(),
+                BoxFailureSnapshot.absent()
+        ))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("idempotencyKey는 비어 있을 수 없습니다.");
+                .hasMessage("PROCESSING 상태는 processingLease를 보유해야 합니다.");
     }
 
     @Test
-    void pending은_idempotencyKey가_공백이면_예외를_던진다() {
+    void rehydrate는_RETRY_PENDING과_absent_failure_조합을_허용하지_않는다() {
         // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        " ",
-                        "api-key",
-                        42L,
-                        "{\"githubPullRequestId\":42}",
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
+        assertThatThrownBy(() -> ReviewRequestInbox.rehydrate(
+                1L,
+                "api-key:42",
+                "api-key",
+                42L,
+                "{}",
+                Instant.parse("2026-02-24T00:00:00Z"),
+                ReviewRequestInboxStatus.RETRY_PENDING,
+                1,
+                BoxProcessingLease.idle(),
+                BoxEventTime.absent(),
+                BoxEventTime.present(Instant.parse("2026-02-24T00:01:00Z")),
+                BoxFailureSnapshot.absent()
+        ))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("idempotencyKey는 비어 있을 수 없습니다.");
+                .hasMessage("RETRY_PENDING 상태는 failure가 있어야 합니다.");
     }
 
     @Test
-    void pending은_apiKey가_null이면_예외를_던진다() {
-        // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        "api-key:42",
-                        null,
-                        42L,
-                        "{\"githubPullRequestId\":42}",
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("apiKey는 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void pending은_apiKey가_공백이면_예외를_던진다() {
-        // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        "api-key:42",
-                        " ",
-                        42L,
-                        "{\"githubPullRequestId\":42}",
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("apiKey는 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void pending은_githubPullRequestId가_null이면_예외를_던진다() {
-        // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        "api-key:42",
-                        "api-key",
-                        null,
-                        "{\"githubPullRequestId\":42}",
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("githubPullRequestId는 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void pending은_githubPullRequestId가_0이면_예외를_던진다() {
-        // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        "api-key:42",
-                        "api-key",
-                        0L,
-                        "{\"githubPullRequestId\":42}",
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("githubPullRequestId는 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void pending은_requestJson이_null이면_예외를_던진다() {
-        // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        "api-key:42",
-                        "api-key",
-                        42L,
-                        null,
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("requestJson은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void pending은_requestJson이_공백이면_예외를_던진다() {
-        // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        "api-key:42",
-                        "api-key",
-                        42L,
-                        " ",
-                        Instant.parse("2026-02-24T00:00:00Z")
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("requestJson은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void pending은_availableAt이_null이면_예외를_던진다() {
-        // when & then
-        assertThatThrownBy(
-                () -> ReviewRequestInbox.pending(
-                        "api-key:42",
-                        "api-key",
-                        42L,
-                        "{\"githubPullRequestId\":42}",
-                        null
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("availableAt은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void markProcessed를_호출하면_PROCESSED_상태와_처리시각이_저장된다() {
+    void markProcessed를_호출하면_처리완료_상태와_처리시각이_저장된다() {
         // given
         ReviewRequestInbox inbox = pendingInbox();
         setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
@@ -190,41 +93,40 @@ class ReviewRequestInboxTest {
         // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSED),
-                () -> assertThat(inbox.getProcessedAt()).isEqualTo(processedAt),
-                () -> assertThat(inbox.getProcessingStartedAt()).isEqualTo(
-                        FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT
-                ),
-                () -> assertThat(inbox.getFailedAt()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_AT),
-                () -> assertThat(inbox.getFailureReason()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_REASON),
-                () -> assertThat(inbox.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
-                () -> assertThat(history).isNotNull(),
-                () -> assertThat(history.getInboxId()).isNull(),
+                () -> assertThat(inbox.hasClaimedProcessingLease()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().occurredAt()).isEqualTo(processedAt),
+                () -> assertThat(inbox.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailure().isPresent()).isFalse(),
                 () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSED),
-                () -> assertThat(history.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE)
+                () -> assertThat(history.getFailure().isPresent()).isFalse()
         );
     }
 
     @Test
-    void markProcessed는_processedAt이_null이면_예외를_던진다() {
+    void hasClaimedProcessingLease는_현재_lease_보유_여부와_시작시각_일치_여부를_제공한다() {
         // given
         ReviewRequestInbox inbox = pendingInbox();
-        setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
+        Instant processingStartedAt = Instant.parse("2026-02-24T00:10:00Z");
+        setProcessingState(inbox, processingStartedAt, 1);
 
         // when & then
-        assertThatThrownBy(() -> inbox.markProcessed(null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("processedAt은 비어 있을 수 없습니다.");
+        assertAll(
+                () -> assertThat(inbox.hasClaimedProcessingLease()).isTrue(),
+                () -> assertThat(inbox.hasClaimedProcessingLease(processingStartedAt)).isTrue(),
+                () -> assertThat(inbox.hasClaimedProcessingLease(processingStartedAt.plusSeconds(1))).isFalse(),
+                () -> assertThat(inbox.currentProcessingLeaseStartedAt()).isEqualTo(processingStartedAt)
+        );
     }
 
     @Test
-    void markProcessed는_PROCESSING_상태가_아니면_예외를_던진다() {
+    void currentProcessingLeaseStartedAt는_lease가_없으면_예외를_던진다() {
         // given
         ReviewRequestInbox inbox = pendingInbox();
 
         // when & then
-        assertThatThrownBy(() -> inbox.markProcessed(Instant.parse("2026-02-24T00:13:00Z")))
+        assertThatThrownBy(inbox::currentProcessingLeaseStartedAt)
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("PROCESSED 전이는 PROCESSING 상태에서만 가능합니다.");
+                .hasMessage("processingLease를 보유하고 있지 않습니다.");
     }
 
     @Test
@@ -240,65 +142,33 @@ class ReviewRequestInboxTest {
         // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
-                () -> assertThat(inbox.getProcessingStartedAt()).isEqualTo(
-                        FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT
-                ),
-                () -> assertThat(inbox.getProcessedAt()).isEqualTo(FailureSnapshotDefaults.NO_PROCESSED_AT),
-                () -> assertThat(inbox.getFailedAt()).isEqualTo(failedAt),
-                () -> assertThat(inbox.getFailureReason()).isEqualTo("retry"),
-                () -> assertThat(inbox.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
-                () -> assertThat(history).isNotNull(),
-                () -> assertThat(history.getInboxId()).isNull(),
-                () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
-                () -> assertThat(history.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE)
+                () -> assertThat(inbox.hasClaimedProcessingLease()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(failedAt),
+                () -> assertThat(inbox.getFailure().reason()).isEqualTo("retry"),
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.RETRYABLE),
+                () -> assertThat(history.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.RETRYABLE)
         );
     }
 
     @Test
-    void markRetryPending은_failedAt이_null이면_예외를_던진다() {
+    void markRetryPending은_PROCESSING_TIMEOUT_failureType을_허용한다() {
         // given
         ReviewRequestInbox inbox = pendingInbox();
         setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
 
-        // when & then
-        assertThatThrownBy(() -> inbox.markRetryPending(null, "retry"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("failedAt은 비어 있을 수 없습니다.");
-    }
+        // when
+        ReviewRequestInboxHistory history = inbox.markRetryPending(
+                Instant.parse("2026-02-24T00:14:00Z"),
+                "timeout",
+                ReviewRequestInboxFailureType.PROCESSING_TIMEOUT
+        );
 
-    @Test
-    void markRetryPending은_failureReason이_null이면_예외를_던진다() {
-        // given
-        ReviewRequestInbox inbox = pendingInbox();
-        setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
-
-        // when & then
-        assertThatThrownBy(() -> inbox.markRetryPending(Instant.parse("2026-02-24T00:14:00Z"), null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("failureReason은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void markRetryPending은_failureReason이_공백이면_예외를_던진다() {
-        // given
-        ReviewRequestInbox inbox = pendingInbox();
-        setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
-
-        // when & then
-        assertThatThrownBy(() -> inbox.markRetryPending(Instant.parse("2026-02-24T00:14:00Z"), " "))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("failureReason은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void markRetryPending은_PROCESSING_상태가_아니면_예외를_던진다() {
-        // given
-        ReviewRequestInbox inbox = pendingInbox();
-
-        // when & then
-        assertThatThrownBy(() -> inbox.markRetryPending(Instant.parse("2026-02-24T00:14:00Z"), "retry"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("RETRY_PENDING 전이는 PROCESSING 상태에서만 가능합니다.");
+        // then
+        assertAll(
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT),
+                () -> assertThat(history.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT)
+        );
     }
 
     @Test
@@ -318,100 +188,29 @@ class ReviewRequestInboxTest {
         // then
         assertAll(
                 () -> assertThat(inbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED),
-                () -> assertThat(inbox.getProcessingStartedAt()).isEqualTo(
-                        FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT
-                ),
-                () -> assertThat(inbox.getProcessedAt()).isEqualTo(FailureSnapshotDefaults.NO_PROCESSED_AT),
-                () -> assertThat(inbox.getFailedAt()).isEqualTo(failedAt),
-                () -> assertThat(inbox.getFailureReason()).isEqualTo("failure"),
-                () -> assertThat(inbox.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
-                () -> assertThat(history).isNotNull(),
-                () -> assertThat(history.getInboxId()).isNull(),
-                () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.FAILED)
+                () -> assertThat(inbox.hasClaimedProcessingLease()).isFalse(),
+                () -> assertThat(inbox.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(inbox.getFailedTime().occurredAt()).isEqualTo(failedAt),
+                () -> assertThat(inbox.getFailure().reason()).isEqualTo("failure"),
+                () -> assertThat(inbox.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE),
+                () -> assertThat(history.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.NON_RETRYABLE)
         );
     }
 
     @Test
-    void markFailed는_failedAt이_null이면_예외를_던진다() {
+    void markFailed는_RETRYABLE_failureType을_허용하지_않는다() {
         // given
         ReviewRequestInbox inbox = pendingInbox();
         setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
 
         // when & then
-        assertThatThrownBy(() -> inbox.markFailed(null, "failure", ReviewRequestInboxFailureType.NON_RETRYABLE))
+        assertThatThrownBy(() -> inbox.markFailed(
+                Instant.parse("2026-02-24T00:15:00Z"),
+                "failure",
+                ReviewRequestInboxFailureType.RETRYABLE
+        ))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("failedAt은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void markFailed는_failureReason이_null이면_예외를_던진다() {
-        // given
-        ReviewRequestInbox inbox = pendingInbox();
-        setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
-
-        // when & then
-        assertThatThrownBy(
-                () -> inbox.markFailed(
-                        Instant.parse("2026-02-24T00:15:00Z"),
-                        null,
-                        ReviewRequestInboxFailureType.NON_RETRYABLE
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("failureReason은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void markFailed는_failureReason이_공백이면_예외를_던진다() {
-        // given
-        ReviewRequestInbox inbox = pendingInbox();
-        setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
-
-        // when & then
-        assertThatThrownBy(
-                () -> inbox.markFailed(
-                        Instant.parse("2026-02-24T00:15:00Z"),
-                        " ",
-                        ReviewRequestInboxFailureType.NON_RETRYABLE
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("failureReason은 비어 있을 수 없습니다.");
-    }
-
-    @Test
-    void markFailed는_failureType이_NONE이면_예외를_던진다() {
-        // given
-        ReviewRequestInbox inbox = pendingInbox();
-        setProcessingState(inbox, Instant.parse("2026-02-24T00:10:00Z"), 1);
-
-        // when & then
-        assertThatThrownBy(
-                () -> inbox.markFailed(
-                        Instant.parse("2026-02-24T00:15:00Z"),
-                        "failure",
-                        ReviewRequestInboxFailureType.NONE
-                )
-        )
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("failureType은 NONE일 수 없습니다.");
-    }
-
-    @Test
-    void markFailed는_PROCESSING_상태가_아니면_예외를_던진다() {
-        // given
-        ReviewRequestInbox inbox = pendingInbox();
-
-        // when & then
-        assertThatThrownBy(
-                () -> inbox.markFailed(
-                        Instant.parse("2026-02-24T00:15:00Z"),
-                        "failure",
-                        ReviewRequestInboxFailureType.NON_RETRYABLE
-                )
-        )
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("FAILED 전이는 PROCESSING 상태에서만 가능합니다.");
+                .hasMessage("FAILED failureType이 올바르지 않습니다.");
     }
 
     private ReviewRequestInbox pendingInbox() {
@@ -426,11 +225,10 @@ class ReviewRequestInboxTest {
 
     private void setProcessingState(ReviewRequestInbox inbox, Instant processingStartedAt, int processingAttempt) {
         ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
-        ReflectionTestUtils.setField(inbox, "processingStartedAt", processingStartedAt);
-        ReflectionTestUtils.setField(inbox, "processedAt", FailureSnapshotDefaults.NO_PROCESSED_AT);
+        ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.claimed(processingStartedAt));
+        ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());
         ReflectionTestUtils.setField(inbox, "processingAttempt", processingAttempt);
-        ReflectionTestUtils.setField(inbox, "failedAt", FailureSnapshotDefaults.NO_FAILURE_AT);
-        ReflectionTestUtils.setField(inbox, "failureReason", FailureSnapshotDefaults.NO_FAILURE_REASON);
-        ReflectionTestUtils.setField(inbox, "failureType", ReviewRequestInboxFailureType.NONE);
     }
 }

--- a/src/test/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxTest.java
+++ b/src/test/java/com/slack/bot/infrastructure/review/box/in/ReviewRequestInboxTest.java
@@ -124,7 +124,7 @@ class ReviewRequestInboxTest {
         ReviewRequestInbox inbox = pendingInbox();
 
         // when & then
-        assertThatThrownBy(inbox::currentProcessingLeaseStartedAt)
+        assertThatThrownBy(() -> inbox.currentProcessingLeaseStartedAt())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("processingLease를 보유하고 있지 않습니다.");
     }

--- a/src/test/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapterTest.java
+++ b/src/test/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapterTest.java
@@ -92,7 +92,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
                 oldAvailableAt
         );
         setProcessingState(inbox, processingStartedAt, 1);
-        ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+        ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
 
         // when
         reviewRequestInboxRepository.upsertPending(
@@ -104,7 +104,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
         );
 
         // then
-        ReviewRequestInbox actual = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+        ReviewRequestInbox actual = jpaReviewRequestInboxRepository.findDomainById(saved.getId()).orElseThrow();
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
                 () -> assertThat(actual.getProcessingAttempt()).isEqualTo(1),
@@ -127,7 +127,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
         );
         setProcessingState(inbox, Instant.parse("2026-02-24T00:01:00Z"), 1);
         inbox.markRetryPending(Instant.parse("2026-02-24T00:02:00Z"), "temporary failure");
-        ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+        ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
 
         // when
         Instant newAvailableAt = Instant.parse("2026-02-24T00:03:00Z");
@@ -140,7 +140,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
         );
 
         // then
-        ReviewRequestInbox actual = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+        ReviewRequestInbox actual = jpaReviewRequestInboxRepository.findDomainById(saved.getId()).orElseThrow();
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.PENDING),
                 () -> assertThat(actual.getProcessingAttempt()).isZero(),
@@ -167,7 +167,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
                 Instant.parse("2026-02-24T00:00:00Z")
         );
         setProcessingState(inbox, Instant.parse("2026-02-24T00:01:00Z"), 1);
-        ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+        ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
         Instant failedAt = Instant.parse("2026-02-24T00:05:00Z");
         LocalDateTime expectedUpdatedAt = LocalDateTime.ofInstant(failedAt, ZoneOffset.UTC);
 
@@ -181,13 +181,14 @@ class ReviewRequestInboxRepositoryAdapterTest {
         );
 
         // then
-        ReviewRequestInbox actual = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+        ReviewRequestInboxJpaEntity actualEntity = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+        ReviewRequestInbox actual = actualEntity.toDomain();
         ReviewRequestInboxHistory history = findLatestHistory(saved.getId());
         assertAll(
                 () -> assertThat(recoveredCount).isEqualTo(1),
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
                 () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
-                () -> assertThat(actual.getUpdatedAt()).isEqualTo(expectedUpdatedAt),
+                () -> assertThat(actualEntity.getUpdatedAt()).isEqualTo(expectedUpdatedAt),
                 () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
                 () -> assertThat(history.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT),
                 () -> assertThat(history.getFailureReason()).isEqualTo("timeout"),
@@ -209,7 +210,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
                     Instant.parse("2026-02-24T00:00:00Z")
             );
             setProcessingState(inbox, base.minusSeconds(120L + index), 1);
-            ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+            ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
             inboxIds.add(saved.getId());
         }
 
@@ -224,9 +225,9 @@ class ReviewRequestInboxRepositoryAdapterTest {
 
         // then
         List<ReviewRequestInbox> actualInboxes = inboxIds.stream()
-                                                         .map(inboxId -> jpaReviewRequestInboxRepository.findById(inboxId).orElseThrow())
+                                                         .map(inboxId -> jpaReviewRequestInboxRepository.findDomainById(inboxId).orElseThrow())
                                                          .toList();
-        List<ReviewRequestInboxHistory> actualHistories = jpaReviewRequestInboxHistoryRepository.findAll();
+        List<ReviewRequestInboxHistory> actualHistories = jpaReviewRequestInboxHistoryRepository.findAllDomains();
         assertAll(
                 () -> assertThat(recoveredCount).isEqualTo(100),
                 () -> assertThat(actualInboxes).filteredOn(inbox -> inbox.getStatus() == ReviewRequestInboxStatus.RETRY_PENDING)
@@ -256,7 +257,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
                     Instant.parse("2026-02-24T00:00:00Z")
             );
             setProcessingState(retryableInbox, base.minusSeconds(200L + index), 1);
-            ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(retryableInbox);
+            ReviewRequestInbox saved = reviewRequestInboxRepository.save(retryableInbox);
             inboxIds.add(saved.getId());
         }
 
@@ -269,7 +270,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
                     Instant.parse("2026-02-24T00:00:00Z")
             );
             setProcessingState(exhaustedInbox, base.minusSeconds(100L + index), 3);
-            ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(exhaustedInbox);
+            ReviewRequestInbox saved = reviewRequestInboxRepository.save(exhaustedInbox);
             inboxIds.add(saved.getId());
         }
 
@@ -284,9 +285,9 @@ class ReviewRequestInboxRepositoryAdapterTest {
 
         // then
         List<ReviewRequestInbox> actualInboxes = inboxIds.stream()
-                                                         .map(inboxId -> jpaReviewRequestInboxRepository.findById(inboxId).orElseThrow())
+                                                         .map(inboxId -> jpaReviewRequestInboxRepository.findDomainById(inboxId).orElseThrow())
                                                          .toList();
-        List<ReviewRequestInboxHistory> actualHistories = jpaReviewRequestInboxHistoryRepository.findAll();
+        List<ReviewRequestInboxHistory> actualHistories = jpaReviewRequestInboxHistoryRepository.findAllDomains();
 
         assertAll(
                 () -> assertThat(recoveredCount).isEqualTo(100),
@@ -316,7 +317,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
                 Instant.parse("2026-02-24T00:00:00Z")
         );
         setProcessingState(inbox, Instant.parse("2026-02-24T00:01:00Z"), 1);
-        ReviewRequestInbox saved = jpaReviewRequestInboxRepository.save(inbox);
+        ReviewRequestInbox saved = reviewRequestInboxRepository.save(inbox);
         CountDownLatch lockAcquired = new CountDownLatch(1);
         CountDownLatch releaseLock = new CountDownLatch(1);
 
@@ -350,11 +351,11 @@ class ReviewRequestInboxRepositoryAdapterTest {
             );
 
             // then
-            ReviewRequestInbox lockedInbox = jpaReviewRequestInboxRepository.findById(saved.getId()).orElseThrow();
+            ReviewRequestInbox lockedInbox = jpaReviewRequestInboxRepository.findDomainById(saved.getId()).orElseThrow();
             assertAll(
                     () -> assertThat(skippedCount).isZero(),
                     () -> assertThat(lockedInbox.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
-                    () -> assertThat(jpaReviewRequestInboxHistoryRepository.findAll()).isEmpty()
+                    () -> assertThat(jpaReviewRequestInboxHistoryRepository.findAllDomains()).isEmpty()
             );
 
             releaseLock.countDown();
@@ -375,7 +376,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
     }
 
     private ReviewRequestInbox findByIdempotencyKey(String idempotencyKey) {
-        for (ReviewRequestInbox inbox : jpaReviewRequestInboxRepository.findAll()) {
+        for (ReviewRequestInbox inbox : jpaReviewRequestInboxRepository.findAllDomains()) {
             if (idempotencyKey.equals(inbox.getIdempotencyKey())) {
                 return inbox;
             }
@@ -386,13 +387,15 @@ class ReviewRequestInboxRepositoryAdapterTest {
 
     private ReviewRequestInboxHistory findLatestHistory(Long inboxId) {
         ReviewRequestInboxHistory latestHistory = null;
+        LocalDateTime latestCreatedAt = null;
 
-        for (ReviewRequestInboxHistory history : jpaReviewRequestInboxHistoryRepository.findAll()) {
-            if (!inboxId.equals(history.getInboxId())) {
+        for (ReviewRequestInboxHistoryJpaEntity historyEntity : jpaReviewRequestInboxHistoryRepository.findAll()) {
+            if (!inboxId.equals(historyEntity.getInboxId())) {
                 continue;
             }
-            if (latestHistory == null || history.getCreatedAt().isAfter(latestHistory.getCreatedAt())) {
-                latestHistory = history;
+            if (latestCreatedAt == null || historyEntity.getCreatedAt().isAfter(latestCreatedAt)) {
+                latestHistory = historyEntity.toDomain();
+                latestCreatedAt = historyEntity.getCreatedAt();
             }
         }
 

--- a/src/test/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapterTest.java
+++ b/src/test/java/com/slack/bot/infrastructure/review/persistence/box/in/ReviewRequestInboxRepositoryAdapterTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.slack.bot.application.IntegrationTest;
-import com.slack.bot.infrastructure.common.FailureSnapshotDefaults;
+import com.slack.bot.infrastructure.common.BoxEventTime;
+import com.slack.bot.infrastructure.common.BoxFailureSnapshot;
+import com.slack.bot.infrastructure.common.BoxProcessingLease;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInbox;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxFailureType;
 import com.slack.bot.infrastructure.review.box.in.ReviewRequestInboxHistory;
@@ -68,13 +70,10 @@ class ReviewRequestInboxRepositoryAdapterTest {
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.PENDING),
                 () -> assertThat(actual.getProcessingAttempt()).isZero(),
-                () -> assertThat(actual.getProcessingStartedAt()).isEqualTo(
-                        FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT
-                ),
-                () -> assertThat(actual.getProcessedAt()).isEqualTo(FailureSnapshotDefaults.NO_PROCESSED_AT),
-                () -> assertThat(actual.getFailedAt()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_AT),
-                () -> assertThat(actual.getFailureReason()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_REASON),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
+                () -> assertThat(actual.hasClaimedProcessingLease()).isFalse(),
+                () -> assertThat(actual.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(actual.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(actual.getFailure().isPresent()).isFalse(),
                 () -> assertThat(actual.getAvailableAt()).isEqualTo(availableAt)
         );
     }
@@ -108,7 +107,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.PROCESSING),
                 () -> assertThat(actual.getProcessingAttempt()).isEqualTo(1),
-                () -> assertThat(actual.getProcessingStartedAt()).isEqualTo(processingStartedAt),
+                () -> assertThat(actual.currentProcessingLeaseStartedAt()).isEqualTo(processingStartedAt),
                 () -> assertThat(actual.getApiKey()).isEqualTo("api-key"),
                 () -> assertThat(actual.getRequestJson()).isEqualTo("{\"pullRequestTitle\":\"old\"}"),
                 () -> assertThat(actual.getAvailableAt()).isEqualTo(oldAvailableAt)
@@ -144,13 +143,10 @@ class ReviewRequestInboxRepositoryAdapterTest {
         assertAll(
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.PENDING),
                 () -> assertThat(actual.getProcessingAttempt()).isZero(),
-                () -> assertThat(actual.getProcessingStartedAt()).isEqualTo(
-                        FailureSnapshotDefaults.NO_PROCESSING_STARTED_AT
-                ),
-                () -> assertThat(actual.getProcessedAt()).isEqualTo(FailureSnapshotDefaults.NO_PROCESSED_AT),
-                () -> assertThat(actual.getFailedAt()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_AT),
-                () -> assertThat(actual.getFailureReason()).isEqualTo(FailureSnapshotDefaults.NO_FAILURE_REASON),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
+                () -> assertThat(actual.hasClaimedProcessingLease()).isFalse(),
+                () -> assertThat(actual.getProcessedTime().isPresent()).isFalse(),
+                () -> assertThat(actual.getFailedTime().isPresent()).isFalse(),
+                () -> assertThat(actual.getFailure().isPresent()).isFalse(),
                 () -> assertThat(actual.getRequestJson()).isEqualTo("{\"pullRequestTitle\":\"new\"}"),
                 () -> assertThat(actual.getAvailableAt()).isEqualTo(newAvailableAt)
         );
@@ -187,11 +183,11 @@ class ReviewRequestInboxRepositoryAdapterTest {
         assertAll(
                 () -> assertThat(recoveredCount).isEqualTo(1),
                 () -> assertThat(actual.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
-                () -> assertThat(actual.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.NONE),
+                () -> assertThat(actual.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT),
                 () -> assertThat(actualEntity.getUpdatedAt()).isEqualTo(expectedUpdatedAt),
                 () -> assertThat(history.getStatus()).isEqualTo(ReviewRequestInboxStatus.RETRY_PENDING),
-                () -> assertThat(history.getFailureType()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT),
-                () -> assertThat(history.getFailureReason()).isEqualTo("timeout"),
+                () -> assertThat(history.getFailure().type()).isEqualTo(ReviewRequestInboxFailureType.PROCESSING_TIMEOUT),
+                () -> assertThat(history.getFailure().reason()).isEqualTo("timeout"),
                 () -> assertThat(history.getCompletedAt()).isEqualTo(failedAt)
         );
     }
@@ -237,7 +233,7 @@ class ReviewRequestInboxRepositoryAdapterTest {
                 () -> assertThat(actualHistories).filteredOn(history -> history.getStatus() == ReviewRequestInboxStatus.RETRY_PENDING)
                         .hasSize(100),
                 () -> assertThat(actualHistories).filteredOn(
-                        history -> history.getFailureType() == ReviewRequestInboxFailureType.PROCESSING_TIMEOUT
+                        history -> history.getFailure().type() == ReviewRequestInboxFailureType.PROCESSING_TIMEOUT
                 ).hasSize(100)
         );
     }
@@ -298,10 +294,10 @@ class ReviewRequestInboxRepositoryAdapterTest {
                 () -> assertThat(actualInboxes).filteredOn(inbox -> inbox.getStatus() == ReviewRequestInboxStatus.PROCESSING)
                         .hasSize(1),
                 () -> assertThat(actualHistories).filteredOn(
-                        history -> history.getFailureType() == ReviewRequestInboxFailureType.PROCESSING_TIMEOUT
+                        history -> history.getFailure().type() == ReviewRequestInboxFailureType.PROCESSING_TIMEOUT
                 ).hasSize(50),
                 () -> assertThat(actualHistories).filteredOn(
-                        history -> history.getFailureType() == ReviewRequestInboxFailureType.RETRY_EXHAUSTED
+                        history -> history.getFailure().type() == ReviewRequestInboxFailureType.RETRY_EXHAUSTED
                 ).hasSize(50)
         );
     }
@@ -367,12 +363,11 @@ class ReviewRequestInboxRepositoryAdapterTest {
 
     private void setProcessingState(ReviewRequestInbox inbox, Instant processingStartedAt, int processingAttempt) {
         ReflectionTestUtils.setField(inbox, "status", ReviewRequestInboxStatus.PROCESSING);
-        ReflectionTestUtils.setField(inbox, "processingStartedAt", processingStartedAt);
-        ReflectionTestUtils.setField(inbox, "processedAt", FailureSnapshotDefaults.NO_PROCESSED_AT);
+        ReflectionTestUtils.setField(inbox, "processingLease", BoxProcessingLease.claimed(processingStartedAt));
+        ReflectionTestUtils.setField(inbox, "processedTime", BoxEventTime.absent());
         ReflectionTestUtils.setField(inbox, "processingAttempt", processingAttempt);
-        ReflectionTestUtils.setField(inbox, "failedAt", FailureSnapshotDefaults.NO_FAILURE_AT);
-        ReflectionTestUtils.setField(inbox, "failureReason", FailureSnapshotDefaults.NO_FAILURE_REASON);
-        ReflectionTestUtils.setField(inbox, "failureType", ReviewRequestInboxFailureType.NONE);
+        ReflectionTestUtils.setField(inbox, "failedTime", BoxEventTime.absent());
+        ReflectionTestUtils.setField(inbox, "failure", BoxFailureSnapshot.absent());
     }
 
     private ReviewRequestInbox findByIdempotencyKey(String idempotencyKey) {


### PR DESCRIPTION
# 관련 이슈 번호
<!-- 해당 PR이 merge되면 닫힐 이슈 번호를 명시해주세요. -->
- closed #108

## 이 PR을 통해 해결하려는 문제가 무엇인가요?

PR 리뷰 요청 시 사용하는 ReviewRequestInbox가 null과 NONE 같은 센티널 값에 의존하고 있어서, 
상태 전이와 실패 이력 해석이 분산되어 있었습니다. 
이로 인해 도메인 상태를 읽을 때 의미가 약했습니다

이번 PR은 ReviewRequestInbox 도메인에서 null 센티널을 제거하고
상태를 null object / enum 기반으로 명시적으로 표현하도록 정리하는 것이 목적입니다

또한 이 변경을 적용하는 과정에서 영속 계층이 DB의 null 표현을 전담하도록 분리해 도메인 모델이 저장소 표현을 직접 알지 않도록 맞췄습니다

## 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
<!-- 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요. -->

- ReviewRequestInbox, ReviewRequestInboxHistory를 영속 모델과 분리해서 도메인 모델이 DB null 표현에 직접 의존하지 않도록 정리했습니다
- processingStartedAt, processedAt, failedAt, failureType, failureReason 등 null 센티널로 표현하던 상태를 BoxProcessingLease, BoxEventTime, BoxFailureSnapshot 기반으로 변경했습니다
- ReviewRequestInboxFailureType.NONE를 제거하고, 실패 상태를 실제 의미가 있는 enum 값으로만 다루도록 정리했습니다
- PENDING, PROCESSING, PROCESSED, FAILED, RETRY_PENDING 상태별 이력 유효성 검증을 명시적으로 강화했습니다
- JPA 엔티티가 도메인 객체와 DB 컬럼 사이 변환을 담당하도록 바꾸어, DB에는 필요 시 null로 저장하되 도메인에서는 null object를 사용하도록 맞췄습니다

## 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?
<!-- 없으면 "없음" 이라고 기재해 주세요 -->

- 남아 있던 메서드 참조와 익명 클래스를 제거했습니다

## Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
<!-- 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요. -->
